### PR TITLE
#30447 added a __format__ method to the datetime module

### DIFF
--- a/Languages/IronPython/IronPython.Modules/datetime.cs
+++ b/Languages/IronPython/IronPython.Modules/datetime.cs
@@ -196,7 +196,6 @@ namespace IronPython.Modules {
             public timedelta __pos__() { return +this; }
             public timedelta __neg__() { return -this; }
             public timedelta __abs__() { return (_days > 0) ? this : -this; }
-
             [SpecialName]
             public timedelta FloorDivide(int y) {
                 return this / y;
@@ -666,6 +665,10 @@ namespace IronPython.Modules {
 
             public virtual string/*!*/ __repr__(CodeContext/*!*/ context) {
                 return string.Format("datetime.date({0}, {1}, {2})", _dateTime.Year, _dateTime.Month, _dateTime.Day);
+            }
+
+            public virtual string __format__(CodeContext/*!*/ context, string dateFormat){
+                return this.strftime(context, dateFormat);
             }
 
             #endregion


### PR DESCRIPTION
I added the **format** method to the datetime.cs. It simply calls the strftime method. 

I looked at the datetimemodule.c file at the **format** call and it also just calls the strftime. Here is the line at the end of the object
return PyObject_CallMethod((PyObject *)self, "strftime", "O", format);

I ran the simple tests to verify the change. I tried running the IronPython.tests with test name test_datetime_cpy but there are alot of failures before my change on that test. 
