### PR TITLE
#23765 change the Equals method to check if the type is either  date or d

### DIFF
--- a/Languages/IronPython/IronPython.Modules/datetime.cs
+++ b/Languages/IronPython/IronPython.Modules/datetime.cs
@@ -562,7 +562,8 @@ namespace IronPython.Modules {
             public override bool Equals(object obj) {
                 if (obj == null) return false;
 
-                if (obj.GetType() == typeof(date)) {
+                Type t = obj.GetType();
+                if (t == typeof(date) || t == typeof(datetime)) {
                     date other = (date)obj;
                     return this._dateTime == other._dateTime;
                 } else {


### PR DESCRIPTION
#23765 change the Equals method to check if the type is either  date or datetime

I just added a check for type  if (t == typeof(date) || t == typeof(datetime)) and then cast. It passes 23765  test scenario
