### PR TITLE
Fixed 31049 by implementing the precision case for integers

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/StringFormatter.cs
+++ b/Languages/IronPython/IronPython/Runtime/StringFormatter.cs
@@ -412,6 +412,12 @@ namespace IronPython.Runtime {
 
             if (_opts.LeftAdj) {
                 AppendLeftAdj(val, fPos, 'D');
+            } else if (_opts.Precision > 0) {
+                // in this case the precision means
+                // the minimum number of characters
+                _opts.FieldWidth = (_opts.Space || _opts.SignChar) ?
+                     _opts.Precision + 1 : _opts.Precision;
+                AppendZeroPad(val, fPos, 'D');
             } else if (_opts.ZeroPad) {
                 AppendZeroPad(val, fPos, 'D');
             } else {


### PR DESCRIPTION
In the case of d and i, the precision format specifier means the minimum number of characters. So, when the precision is > 0, set the fieldwidth correctly and then pad with zeroes. This also takes into account if the format specifier has a space instead of a zero. The output matches that done by CPython.

CPython:
Python 2.7.1+ (r271:86832, Apr 11 2011, 18:13:53) 
[GCC 4.5.2] on linux2
Type "help", "copyright", "credits" or "license" for more information.

> > > print '%0.3d' % 5
> > > 005
> > > print '% .3d' % 5
> > >  005
> > > print '%0.3d' % 5005
> > > 5005

IronPython:
IronPython 3.0 DEBUG (3.0.0.0) on .NET 4.0.30319.1
Type "help", "copyright", "credits" or "license" for more information.

> > > print '%0.3d' % 5
> > > 005
> > > print '% .3d' % 5
> > >  005
> > > print '%0.3d' % 5005
> > > 5005
