### PR TITLE
Small WIN32OLE extension to support remote objects

### DIFF
--- a/Languages/Ruby/StdLib/ironruby/win32ole.rb
+++ b/Languages/Ruby/StdLib/ironruby/win32ole.rb
@@ -23,12 +23,12 @@ class WIN32OLE
   # inteorp of passing RCW arguments, better perf since it will avail of call-site
   # caching, and object identity.
   
-  def initialize(arg)
+  def initialize(arg, server = nil)
     if arg.respond_to? :to_str
       if guid? arg
-        type = System::Type.GetTypeFromCLSID arg
+        type = System::Type.GetTypeFromCLSID arg, server, true
       else
-        type = System::Type.GetTypeFromProgID arg
+        type = System::Type.GetTypeFromProgID arg, server, true
       end
       @com_object = System::Activator.create_instance type
     else


### PR DESCRIPTION
Added server argument to WIN32OLE class to support loading objects on a remote machine.
