### PR TITLE
Buffer implements IList<byte>

### DIFF
--- a/Languages/IronPython/IronPython.Modules/_bytesio.cs
+++ b/Languages/IronPython/IronPython.Modules/_bytesio.cs
@@ -499,8 +499,6 @@ namespace IronPython.Modules {
                     return DoWrite(((ArrayModule.array)bytes).ToByteArray()); // as byte[]
                 } else if (bytes is ICollection<byte>) {
                     return DoWrite((ICollection<byte>)bytes);
-                } else if (bytes is PythonBuffer) {
-                    return DoWrite(((PythonBuffer)bytes).ToString()); // as string
                 } else if (bytes is string) {
                     // TODO Remove this when we move to 3.x
                     return DoWrite((string)bytes); // as string

--- a/Languages/IronPython/IronPython.Modules/_fileio.cs
+++ b/Languages/IronPython/IronPython.Modules/_fileio.cs
@@ -477,11 +477,6 @@ namespace IronPython.Modules {
                     return write(bBytes);
                 }
 
-                PythonBuffer bBuffer = b as PythonBuffer;
-                if (bBuffer != null) {
-                    return write(bBuffer.ToString());
-                }
-
                 ArrayModule.array bPythonArray = b as ArrayModule.array;
                 if (bPythonArray != null) {
                     return write(bPythonArray.ToByteArray());

--- a/Languages/IronPython/IronPython.Modules/_io.cs
+++ b/Languages/IronPython/IronPython.Modules/_io.cs
@@ -3214,9 +3214,7 @@ namespace IronPython.Modules {
 
             string str = buf as string;
             if (str == null) {
-                if (buf is PythonBuffer) {
-                    str = ((PythonBuffer)buf).ToString();
-                } else if (buf is Extensible<string>) {
+                if (buf is Extensible<string>) {
                     str = ((Extensible<string>)buf).Value;
                 }
             }

--- a/Languages/IronPython/IronPython.Modules/_md5.cs
+++ b/Languages/IronPython/IronPython.Modules/_md5.cs
@@ -104,11 +104,6 @@ namespace IronPython.Modules {
                 update(initialBytes);
             }
 
-            internal MD5Type(PythonBuffer initialBuffer) {
-                _bytes = new byte[0];
-                update(initialBuffer);
-            }
-
             [Documentation("update(string) -> None (update digest with string data)")]
             public void update(object newData) {
                 update(Converter.ConvertToString(newData).MakeByteArray());
@@ -126,7 +121,7 @@ namespace IronPython.Modules {
 
             [Documentation("update(bytes) -> None (update digest with string data)")]
             public void update(PythonBuffer newData) {
-                update(newData.ToString().MakeByteArray());
+                update((IList<byte>)newData);
             }
 
             private void update(IList<byte> newBytes) {

--- a/Languages/IronPython/IronPython.Modules/_sha.cs
+++ b/Languages/IronPython/IronPython.Modules/_sha.cs
@@ -108,11 +108,6 @@ namespace IronPython.Modules {
                 update(initialBytes);
             }
 
-            internal sha(PythonBuffer initialBuffer) {
-                _bytes = new byte[0];
-                update(initialBuffer);
-            }
-
             [Documentation("update(string) -> None (update digest with string data)")]
             public void update(object newData) {
                 update(Converter.ConvertToString(newData).MakeByteArray());
@@ -123,7 +118,7 @@ namespace IronPython.Modules {
             }
 
             public void update(PythonBuffer newBytes) {
-                update(newBytes.ToString().MakeByteArray());
+                update((IList<byte>)newBytes);
             }
 
             public void update(ByteArray newBytes) {

--- a/Languages/IronPython/IronPython.Modules/_sha256.cs
+++ b/Languages/IronPython/IronPython.Modules/_sha256.cs
@@ -54,7 +54,7 @@ namespace IronPython.Modules {
         }
 
         public static Sha256Object sha256(PythonBuffer data) {
-            return new Sha256Object(data);
+            return new Sha256Object((IList<byte>)data);
         }
 
         public static Sha256Object sha256(ByteArray data) {
@@ -89,11 +89,6 @@ namespace IronPython.Modules {
             internal Sha256Object(IList<byte> initialBytes) {
                 _bytes = new byte[0];
                 update(initialBytes);
-            }
-
-            internal Sha256Object(PythonBuffer initialBuffer) {
-                _bytes = new byte[0];
-                update(initialBuffer);
             }
 
             internal override HashAlgorithm Hasher {
@@ -155,7 +150,7 @@ namespace IronPython.Modules {
         }
 
         public void update(PythonBuffer buffer) {
-            update(buffer.ToString().MakeByteArray());
+            update((IList<byte>)buffer);
         }
 
         [Documentation("digest() -> int (current digest value)")]

--- a/Languages/IronPython/IronPython.Modules/_sha512.cs
+++ b/Languages/IronPython/IronPython.Modules/_sha512.cs
@@ -61,9 +61,9 @@ namespace IronPython.Modules {
         public static Sha512Object sha512(Bytes data) {
             return new Sha512Object((IList<byte>)data);
         }
-		
+        
         public static Sha512Object sha512(PythonBuffer data) {
-            return new Sha512Object(data);
+            return new Sha512Object((IList<byte>)data);
         }
 
         public static Sha512Object sha512(ByteArray data) {
@@ -83,14 +83,14 @@ namespace IronPython.Modules {
         }
 
         public static Sha384Object sha384(PythonBuffer data) {
-            return new Sha384Object(data);
+            return new Sha384Object((IList<byte>)data);
         }
 
         public static Sha384Object sha384(ByteArray data) {
             return new Sha384Object((IList<byte>)data);
         }
 
-		
+        
         public static Sha384Object sha384() {
             return new Sha384Object();
         }
@@ -107,11 +107,6 @@ namespace IronPython.Modules {
             internal Sha384Object(IList<byte> initialBytes) {
                 _bytes = new byte[0];
                 update(initialBytes);
-            }
-
-            internal Sha384Object(PythonBuffer initialBuffer) {
-                _bytes = new byte[0];
-                update(initialBuffer);
             }
 
             internal override HashAlgorithm Hasher {
@@ -147,11 +142,6 @@ namespace IronPython.Modules {
             internal Sha512Object(IList<byte> initialBytes) {
                 _bytes = new byte[0];
                 update(initialBytes);
-            }
-
-            internal Sha512Object(PythonBuffer initialBuffer) {
-                _bytes = new byte[0];
-				update(initialBuffer);
             }
 
             internal override HashAlgorithm Hasher {

--- a/Languages/IronPython/IronPython.Modules/array.cs
+++ b/Languages/IronPython/IronPython.Modules/array.cs
@@ -272,7 +272,9 @@ namespace IronPython.Modules {
             }
 
             public void fromstring([NotNull]PythonBuffer buf) {
-                fromstring(buf.ToString());
+                if ((buf.Size % itemsize) != 0) throw PythonOps.ValueError("string length not a multiple of itemsize");
+
+                FromStream(new MemoryStream(buf.byteCache, false));
             }
 
             public void fromunicode(CodeContext/*!*/ context, string s) {

--- a/Languages/IronPython/IronPython.Modules/socket.cs
+++ b/Languages/IronPython/IronPython.Modules/socket.cs
@@ -637,7 +637,7 @@ namespace IronPython.Modules {
                 + "had room to buffer your data for a network send"
                 )]
             public int send(PythonBuffer data, [DefaultParameterValue(0)] int flags) {
-                byte[] buffer = data.ToString().MakeByteArray();
+                byte[] buffer = data.byteCache;
                 try {
                     return _socket.Send(buffer, (SocketFlags)flags);
                 } catch (Exception e) {
@@ -699,7 +699,7 @@ namespace IronPython.Modules {
                 + "had room to buffer your data for a network send"
                 )]
             public void sendall(PythonBuffer data, [DefaultParameterValue(0)] int flags) {
-                byte[] buffer = data.ToString().MakeByteArray();
+                byte[] buffer = data.byteCache;
                 try {
                     int bytesTotal = buffer.Length;
                     int bytesRemaining = bytesTotal;

--- a/Languages/IronPython/IronPython/Runtime/PythonBuffer.cs
+++ b/Languages/IronPython/IronPython/Runtime/PythonBuffer.cs
@@ -291,7 +291,7 @@ namespace IronPython.Runtime {
 
         #region IList[System.Byte] implementation
         byte[] _objectByteCache = null;
-        byte[] byteCache {
+        internal byte[] byteCache {
             get {
                 return _objectByteCache ?? (_objectByteCache = PythonOps.ConvertBufferToByteArray(this));
             }

--- a/Languages/IronPython/IronPython/Runtime/PythonFile.cs
+++ b/Languages/IronPython/IronPython/Runtime/PythonFile.cs
@@ -1614,35 +1614,7 @@ namespace IronPython.Runtime {
         }
 
         public void write([NotNull]PythonBuffer buf) {
-            WriteWorker(buf, true);
-        }
-
-        private void WriteWorker(PythonBuffer/*!*/ buf, bool locking) {
-            Debug.Assert(buf != null);
-
-            string str = buf._object as string;
-            IPythonArray pyArr;
-            if (str != null || buf._object is IList<byte>) {
-                if (locking) {
-                    write(buf.ToString());
-                } else {
-                    WriteNoLock(buf.ToString());
-                }
-            } else if (buf._object is Array) {
-                throw new NotImplementedException("writing buffer of .NET array to file");
-            } else if ((pyArr = buf._object as IPythonArray) != null) {
-                if (_fileMode != PythonFileMode.Binary) {
-                    throw PythonOps.TypeError("char buffer type not available");
-                }
-
-                if (locking) {
-                    write(pyArr.tostring());
-                } else {
-                    WriteNoLock(pyArr.tostring());
-                }
-            } else {
-                Debug.Assert(false, "unsupported buffer object");
-            }
+            write((IList<byte>)buf);
         }
 
         public void write([NotNull]object arr) {
@@ -1685,7 +1657,7 @@ namespace IronPython.Runtime {
 
                         PythonBuffer buf = e.Current as PythonBuffer;
                         if (buf != null) {
-                            WriteWorker(buf, false);
+                            WriteNoLock(buf);
                             continue;
                         }
 


### PR DESCRIPTION
These patches make PythonBuffer explicitly implement IList<byte>, and then remove some uses of PythonBuffer that are now redundant or can be sped up by directly using the internal byte[] cache.

The byte[] cache isn't necessary, but it's likely to be faster. Large buffers will suffer extra memory usage, though, but only if they are converted to IList<byte> (if not, the cache is never created). Space vs. time, as always.
