### PR TITLE
An anonymous Module should be passed to its own block.

### DIFF
--- a/Languages/Ruby/Ruby/Builtins/RubyModule.cs
+++ b/Languages/Ruby/Ruby/Builtins/RubyModule.cs
@@ -790,7 +790,8 @@ namespace IronRuby.Builtins {
         // Ruby constructor:
         public static object CreateAnonymousModule(RubyScope/*!*/ scope, BlockParam body, RubyClass/*!*/ self) {
             RubyModule newModule = new RubyModule(self, null);
-            return (body != null) ? RubyUtils.EvaluateInModule(newModule, body, null, newModule) : newModule;
+            var args = new object[] { newModule };
+            return (body != null) ? RubyUtils.EvaluateInModule(newModule, body, args, newModule) : newModule;
         }
 
         // thread safe:


### PR DESCRIPTION
An anonymous Module should be passed to its own block.

Fix for [work item 6538](http://ironruby.codeplex.com/workitem/6538).
