### PR TITLE
Fix some missed redirections via PlatformAdaptationLayer in IronPython Importer.

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/Importer.cs
+++ b/Languages/IronPython/IronPython/Runtime/Importer.cs
@@ -732,8 +732,9 @@ namespace IronPython.Runtime {
 
         internal static PythonModule TryImportSourceFile(PythonContext/*!*/ context, string/*!*/ name) {
             var sourceUnit = TryFindSourceFile(context, name);
+            PlatformAdaptationLayer pal = context.DomainManager.Platform;
             if (sourceUnit == null ||
-                GetFullPathAndValidateCase(context, Path.Combine(Path.GetDirectoryName(sourceUnit.Path), name + Path.GetExtension(sourceUnit.Path)), false) == null) {
+                GetFullPathAndValidateCase(context, pal.CombinePaths(pal.GetDirectoryName(sourceUnit.Path), name + pal.GetExtension(sourceUnit.Path)), false) == null) {
                 return null;
             }
 
@@ -770,7 +771,7 @@ namespace IronPython.Runtime {
                     string fullPath;
 
                     try {
-                        fullPath = Path.Combine(directory, name + extension);
+                        fullPath = context.DomainManager.Platform.CombinePaths(directory, name + extension);
                     } catch (ArgumentException) {
                         // skip invalid paths
                         continue;
@@ -856,7 +857,7 @@ namespace IronPython.Runtime {
         private static object LoadFromDisk(CodeContext context, string name, string fullName, string str) {
             // default behavior
             PythonModule module;
-            string pathname = Path.Combine(str, name);
+            string pathname = context.LanguageContext.DomainManager.Platform.CombinePaths(str, name);
 
             module = LoadPackageFromSource(context, fullName, pathname);
             if (module != null) {
@@ -949,7 +950,7 @@ namespace IronPython.Runtime {
                 return null;
             }
 
-            return LoadModuleFromSource(context, name, Path.Combine(path, "__init__.py"));
+            return LoadModuleFromSource(context, name, context.LanguageContext.DomainManager.Platform.CombinePaths(path, "__init__.py"));
         }
 
         private static PythonModule/*!*/ LoadFromSourceUnit(CodeContext/*!*/ context, SourceUnit/*!*/ sourceCode, string/*!*/ name, string/*!*/ path) {


### PR DESCRIPTION
This is just continuing the work in jschementi's commit back in April, https://github.com/IronLanguages/main/commit/394408e467bce8ba278e89f8e6f051521388742c#Languages/IronPython/IronPython/Runtime/Importer.cs to make it more usable.

The process for preparing pull requests seems a bit outdated (sending mails on IronRuby lists for IronPython code changes?) seems a bit outdated, so I just created an issue on the IronPython codeplex page yesterday, and since I got no reply there I created this pull req. It's pretty much  a no-brainer, possibly apart from Silverlight support which I don't know anything about.
