### PR TITLE
FIX - Issue 30412: Booleans get converted to ints by str.format

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/Operations/BoolOps.cs
+++ b/Languages/IronPython/IronPython/Runtime/Operations/BoolOps.cs
@@ -87,6 +87,11 @@ namespace IronPython.Runtime.Operations {
             return self ? "True" : "False";
         }
 
+        public static string/*!*/ __format__(CodeContext/*!*/ context, bool self, [NotNull]string/*!*/ formatSpec)
+        {
+            return __repr__(self);
+        }
+
         // Binary Operations - Comparisons
         [SpecialName]
         public static bool Equals(bool x, bool y) {


### PR DESCRIPTION
In BoolOps.cs; Added **format** function to call **repr**  to generate the String representation. As specified in Issue 30412; In "CPython 2.7, the result is 'True'."
With this change; IronPython now generates the same result.
