### PR TITLE
Fix for IronPython loading under Silverlight 4 and 5 runtimes.

### DIFF
--- a/Languages/IronPython/IronPython/Modules/sys.cs
+++ b/Languages/IronPython/IronPython/Modules/sys.cs
@@ -58,6 +58,8 @@ namespace IronPython.Modules {
                 prefix = String.Empty;
             } catch (ArgumentException) {
                 prefix = String.Empty;
+            } catch (MethodAccessException) {
+                prefix = String.Empty;
             }
 #else
             prefix = String.Empty;

--- a/Languages/IronPython/IronPython/Runtime/PythonContext.cs
+++ b/Languages/IronPython/IronPython/Runtime/PythonContext.cs
@@ -2012,6 +2012,8 @@ namespace IronPython.Runtime {
             } catch (SecurityException) {
                 // we don't have permissions to get paths...
                 return String.Empty;
+            } catch (MethodAccessException) {
+                return String.Empty;
             }
 #else
             return String.Empty;


### PR DESCRIPTION
Reported in CodePlex issue: http://ironpython.codeplex.com/workitem/32596

I have tested this fix under both Silverlight 4 and 5.
