### PR TITLE
Silverlight 4/5 build fixes

### DIFF
--- a/Languages/IronPython/IronPython.Modules/ResourceMetaPathImporter.cs
+++ b/Languages/IronPython/IronPython.Modules/ResourceMetaPathImporter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -89,8 +88,7 @@ fully qualified (dotted) module name. It returns the imported
 module, or raises ResourceImportError if it wasn't found."
             )]
         public object load_module(CodeContext /*!*/ context, string fullname) {
-            dynamic sys = context.LanguageContext.SystemState;
-            PythonDictionary modules = sys.modules;
+            var modules = (PythonDictionary)context.LanguageContext.SystemState.__dict__.get("modules");
             if (modules.Contains(fullname))
                 return modules[fullname];
 
@@ -253,7 +251,7 @@ module, or raises ResourceImportError if it wasn't found."
                 try {
                     var parsedSources =
                         from entry in files.Values
-                        let isPyFile = entry.FullName.EndsWith(".py", true, CultureInfo.InvariantCulture)
+                        let isPyFile = entry.FullName.EndsWith(".py", StringComparison.InvariantCultureIgnoreCase)
                         where isPyFile
                         let name = entry.FullName.Substring(0, entry.FullName.Length - 3)
                         let dottedName = name.Replace('\\', '.').Replace('/', '.')


### PR DESCRIPTION
This should resolve the build failures under Silverlight 4 and 5 for IronPython.Modules, however there is a separate build issue with the dependency to Microsoft.Dynamic which no longer builds as of commit 4d99cbae91724fc9b982b581d5ad79193991439e ("Win8 build fixes"). I was only able to get that project to build successfully after reverting the commit from a local branch.

It may be best to pull a resolution for the dependency build issue at the same time as this patch, since the solution will not build without it.
