### PR TITLE
Removed reliance on runtime binder (doesn't work in Silverlight).

### DIFF
--- a/Languages/IronPython/IronPython.Modules/ResourceMetaPathImporter.cs
+++ b/Languages/IronPython/IronPython.Modules/ResourceMetaPathImporter.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -88,9 +87,8 @@ fully qualified (dotted) module name. It returns the imported
 module, or raises ResourceImportError if it wasn't found."
             )]
         public object load_module(CodeContext /*!*/ context, string fullname) {
-            dynamic sys = context.LanguageContext.SystemState;
-            PythonDictionary modules = sys.modules;
-            if (modules.Contains(fullname))
+            var modules = context.LanguageContext.SystemStateModules;
+            if (modules.ContainsKey(fullname))
                 return modules[fullname];
 
             bool ispackage;


### PR DESCRIPTION
Removes the unnecessary usage of "dynamic", allowing compile under Silverlight profiles.
