### PR TITLE
Fix for "Duplicate key in dict" issue

### DIFF
--- a/Languages/IronPython/Tests/test_dict.py
+++ b/Languages/IronPython/Tests/test_dict.py
@@ -1172,4 +1172,22 @@ def test_dict_comp():
         abc = {x:x for x in t if x == v}
         AreEqual(abc, {2:2})
 
+def test_cp32527():
+    '''test for duplicate key in dict under specific hash value conditions'''
+    d = {'1': 1, '2': 1, '3': 1, 'a7': 1, 'a8': 1}
+    #d now has 7 buckets internally, and computed hash for a7 and a8 keys will land on same starting bucket index
+    
+    #recycle the a7 bucket
+    d.pop('a7')
+    
+    #attempt to update the a8 bucket, which now comes after the recycled a7
+    d['a8'] = 5
+    
+    #if working properly, there will now be a recycled bucket (former home of a7) and a single a8 bucket
+    #if not working properly, there will instead be two a8 buckets
+    expected = 1
+    actual = d.keys().count('a8')
+    AreEqual(actual, expected)
+
+
 run_test(__name__)


### PR DESCRIPTION
This is a pretty scary class, seemingly optimized for concurrent access. Even though the change I made to fix this nasty little bug is pretty small, I would appreciate a second set of eyes on the solution before merging.

I am particularly concerned that fixing the bug will mean that inserting new dictionary values will become a guaranteed O(n) operation instead of the current O(1) cost. I just didn't see any way around that.

Updates to existing entries should still be O(1). It's the inserts that will be impacted.

Issue was reported and discussed here: http://ironpython.codeplex.com/workitem/32527
- Additionally, while trying to decipher the code in this class I noticed that there appears to be no way to ever compact the storage. It will grow when needed, but I see no mechanism for compacting back down short of clearing and reloading or copying the entries to a new dict. I'm not even sure that compaction is even something to be too concerned about, but it seems odd that it would be omitted when the rest of the implementation appears to be so focused on efficiency.
