### PR TITLE
Enable building of the IronRuby installer.

### DIFF
--- a/Msi/Installer.proj
+++ b/Msi/Installer.proj
@@ -2,20 +2,16 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
     <PropertyGroup>
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     </PropertyGroup>
     <ItemGroup>
         <!-- Needed to be built ahead of time for the MSIs to include the Silverlight binaries -->
         <ProjectToBuild Include="..\Solutions\Dlr.sln">
             <Properties>Configuration=Silverlight4$(Configuration)</Properties>
         </ProjectToBuild>  
-        <ProjectToBuild Include="Python\Chm\IronPython.Chm.proj">
-          <Name>IronPython.Chm</Name>
-        </ProjectToBuild>  
-        <ProjectToBuild Include="Python\Msi\IronPython.Msi.wproj">
-            <Properties>Configuration=$(Configuration)</Properties>
-        </ProjectToBuild>
+        <!-- It looks like the IronPython installer has been rewritten as a seperate wixproj... -->
         <ProjectToBuild Include="Ruby\Msi\IronRuby.Msi.wproj">
-            <Properties>Configuration=$(Configuration)</Properties>
+            <Properties>Configuration=$(Configuration);TreatWarningsAsErrors=false</Properties>
         </ProjectToBuild>
     </ItemGroup>
 

--- a/Msi/IronStudio/IronStudio.msm.wproj
+++ b/Msi/IronStudio/IronStudio.msm.wproj
@@ -5,6 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{5B4E8D5A-1066-4FFE-894A-448CDD868F0B}</ProjectGuid>
+    <DefineSolutionProperties>false</DefineSolutionProperties>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/Msi/Ruby/Msi/IronRuby.Msi.wproj
+++ b/Msi/Ruby/Msi/IronRuby.Msi.wproj
@@ -9,6 +9,8 @@
     <OutputName Condition="$(OutputName)==''">IronRuby</OutputName>
     <OutputType Condition="$(OutputType)==''">Package</OutputType>
 
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+
     <!-- Paths -->
     <DlrRoot>$(SolutionDir)..\</DlrRoot>
     <VsToolsDir>$(DlrRoot)Tools\IronStudio\IronRubyTools</VsToolsDir>
@@ -27,6 +29,7 @@
       VsToolsPrivateBinDir=$(VsToolsDir)\obj\$(Configuration)\;
       SilverlightScriptDir=$(DlrRoot)Hosts\SilverLight\Public\script;
       SilverlightDir=$(DlrRoot)Bin\Silverlight4$(Configuration);
+      OutputPath=$(OutputPath);
       $(DefineConstants)
     </DefineConstants>
   </PropertyGroup>

--- a/Msi/Ruby/Msi/IronRuby.wxs
+++ b/Msi/Ruby/Msi/IronRuby.wxs
@@ -169,6 +169,7 @@ WHEN PERFORMING MAJOR IR UPGRADES (e.g., 1.0 => 1.1):
       <Feature Id="Feature_SL" AllowAdvertise="no" Level="1" Title="Silverlight Support" Description="IronRuby for Silverlight.">
         <Feature Id="Feature_SL_Binaries" AllowAdvertise="no" Level="1" Title="Binaries" Description="IronRuby binaries targeting Silverlight.">
           <ComponentRef Id="Comp_SL" />
+          <ComponentRef Id="Comp_Chiron" />
         </Feature>
 
         <Feature Id="Feature_SLTemplates" AllowAdvertise="no" Level="1" Title="Templates" Description="Templates supporting IronRuby Silverlight development.">

--- a/Msi/Ruby/Msi/Silverlight.wxi
+++ b/Msi/Ruby/Msi/Silverlight.wxi
@@ -10,11 +10,9 @@
       <File Name="IronRuby.Libraries.Yaml.dll" />
       <File Name="System.Numerics.dll" />
     </Component>
-  </Directory>
-  <Directory Id="Dir_Silverlight_bin" Name="bin" FileSource="$(var.OutputPath)">
     <Component Id="Comp_Chiron" DiskId="1" Guid="504F28C5-1607-42FD-8425-4309699017C4">
-      <File Name="Chiron.exe" />
-      <File Name="Chiron.exe.Config" />
+      <File Name="Chiron.exe" Source="$(var.OutputPath)" />
+      <File Name="Chiron.exe.Config" Source="$(var.OutputPath)" />
     </Component>
   </Directory>
   <Directory Id="Dir_Silverlight_script" Name="script" FileSource="$(var.SilverlightScriptDir)">

--- a/Msi/Ruby/Msm/IrbRedist.wxs
+++ b/Msi/Ruby/Msm/IrbRedist.wxs
@@ -50,8 +50,8 @@
 
             <Component Id="C32IrbYaml" DiskId="1" Guid="1EA2194E-83AD-4124-8288-962CA767A508">
               <Condition>NOT VersionNT64</Condition>
-              <File Id="NGENFile_IronRuby.Libraries.Yaml.dll" Name="IronRuby.Libraries.Yaml.dll" Assembly=".net" KeyPath="yes" Source="IronRuby.Libraries.Yaml.dll">
-                <netfx:NativeImage Id="NGEN_File_IronRuby.Libraries.Yaml.dll" Priority="1"/>
+              <File Id="NGENFile_IR.Libraries.Yaml" Name="IronRuby.Libraries.Yaml.dll" Assembly=".net" KeyPath="yes" Source="IronRuby.Libraries.Yaml.dll">
+                <netfx:NativeImage Id="NGENFile_IR.Libraries.Yaml" Priority="1"/>
               </File>
             </Component>
 
@@ -83,8 +83,8 @@
 
             <Component Id="C64IrbYaml" DiskId="1" Guid="2BF6571B-A914-4CE7-8127-C03DEB5C8D12">
               <Condition>VersionNT64</Condition>
-              <File Id="NGEN64File_IronRuby.Libraries.Yaml.dll" Name="IronRuby.Libraries.Yaml.dll" Assembly=".net" KeyPath="yes">
-                <netfx:NativeImage Id="NGEN64_File_IronRuby.Libraries.Yaml.dll" Priority="1" Platform="all" />
+              <File Id="NGEN64File_IR.Libraries.Yaml.dll" Name="IronRuby.Libraries.Yaml.dll" Assembly=".net" KeyPath="yes">
+                <netfx:NativeImage Id="NGEN64_File_IR.Libraries.Yaml.dll" Priority="1" Platform="all" />
               </File>
             </Component>
 

--- a/Msi/Runtime/DLR.Msm.wproj
+++ b/Msi/Runtime/DLR.Msm.wproj
@@ -5,6 +5,7 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProjectGuid>{81A2FD44-53F8-47E3-9B3B-C0883D140867}</ProjectGuid>
+    <DefineSolutionProperties>false</DefineSolutionProperties>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>

--- a/Msi/Runtime/DLR.wxs
+++ b/Msi/Runtime/DLR.wxs
@@ -14,8 +14,8 @@
           </Component>
           <Component Id="Comp_32_MSScriptingMetadata" DiskId="1" Guid="4C993FD7-4AE7-4D0D-94E2-6708D7E9F596">
             <Condition>NOT VersionNT64</Condition>
-            <File Id="NGENFile_Microsoft.Scripting.Metadata.dll" Name="Microsoft.Scripting.Metadata.dll" Assembly=".net" KeyPath="yes" Source="Microsoft.Scripting.Metadata.dll">
-              <netfx:NativeImage Id="NGEN_File_Microsoft.Scripting.Metadata.dll" Priority="1"/>
+            <File Id="NGENFile_MS.Scripting.Metadata.dll" Name="Microsoft.Scripting.Metadata.dll" Assembly=".net" KeyPath="yes" Source="Microsoft.Scripting.Metadata.dll">
+              <netfx:NativeImage Id="NGENFile_MS.Scripting.Metadata.dll" Priority="1"/>
             </File>
           </Component>
           <Component Id="Comp_32_MSDynamic" DiskId="1" Guid="77E05B31-C89B-4C1F-AA4A-05373809067A">
@@ -34,8 +34,8 @@
           </Component>
           <Component Id="Comp_64_MSScriptingMetadata" DiskId="1" Guid="DCF89765-2F2F-4D8B-B8EA-32E888FAC975">
             <Condition>VersionNT64</Condition>
-            <File Id="NGEN64File_Microsoft.Scripting.Metadata.dll" Name="Microsoft.Scripting.Metadata.dll" Assembly=".net" KeyPath="yes">
-              <netfx:NativeImage Id="NGEN64_File_Microsoft.Scripting.Metadata.dll" Priority="1" Platform="all" />
+            <File Id="NGEN64File_MSScriptingMetadata" Name="Microsoft.Scripting.Metadata.dll" Assembly=".net" KeyPath="yes">
+              <netfx:NativeImage Id="NGEN64File_MSScriptingMetadata" Priority="1" Platform="all" />
             </File>
           </Component>
           <Component Id="Comp_64_MSDynamic" DiskId="1" Guid="7636A16F-44F3-463F-8DBB-9BD1207D49BB">

--- a/Tools/IronStudio/IronRubyTools/IronRubyTools.csproj
+++ b/Tools/IronStudio/IronRubyTools/IronRubyTools.csproj
@@ -11,8 +11,10 @@
     <ProjectGuid>{3467BF9A-3A0F-42BE-85E3-E818E7D3E2E8}</ProjectGuid>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\IronRubyToolsCore\IronRubyToolsCore.csproj">
@@ -159,7 +161,7 @@
     <Reference Include="System.Xaml" />
     <Reference Include="UIAutomationProvider" />
     <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
+      <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="VSLangProj100, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/Tools/IronStudio/IronRubyToolsCore/IronRubyToolsCore.csproj
+++ b/Tools/IronStudio/IronRubyToolsCore/IronRubyToolsCore.csproj
@@ -10,8 +10,10 @@
     <AssemblyName>IronRubyTools.Core</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=0.0.0.0, Culture=neutral">

--- a/Tools/IronStudio/IronStudio/IronStudio.csproj
+++ b/Tools/IronStudio/IronStudio/IronStudio.csproj
@@ -10,8 +10,10 @@
     <AssemblyName>IronStudio</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Hosts\SilverLight\Chiron\Chiron.csproj">


### PR DESCRIPTION
- Disable WarningsAsErrors (else can't more than one of the MSM's into the IronRuby MSI)
- Fix duplicate directory node error caused by addition of chiron
- Fix some WIX warnings re: file KeyPaths being too long
- Fix some WIX warnings re: DefineSolutionProperties
- Set EmbedInteropTypes so IronRubyToolsCore.csproj builds
- Fix warnings by changing some studio projects to build as x86
