### PR TITLE
Allow LanguageContext to control Scope creation

### DIFF
--- a/Runtime/Microsoft.Scripting/Hosting/ScriptEngine.cs
+++ b/Runtime/Microsoft.Scripting/Hosting/ScriptEngine.cs
@@ -234,13 +234,22 @@ namespace Microsoft.Scripting.Hosting {
 
         #region Scopes
 
+        /// <summary>
+        /// Creates a new ScriptScope using the default storage container
+        /// </summary>
         public ScriptScope CreateScope() {
-            return new ScriptScope(this, new Scope());
+            return new ScriptScope(this, _language.CreateScope());
         }
 
-        public ScriptScope CreateScope(IDictionary<string, object> dictionary) {
+        /// <summary>
+        /// Creates a new ScriptScope whose storage contains the provided dictionary of objects
+        /// 
+        /// Accesses to the ScriptScope will turn into get,set, and delete members against this dictionary
+        /// </summary>
+        public ScriptScope CreateScope(IDictionary<string, object> dictionary)
+        {
             ContractUtils.RequiresNotNull(dictionary, "dictionary");
-            return new ScriptScope(this, new Scope(dictionary));
+            return new ScriptScope(this, _language.CreateScope(dictionary));
         }
 
         /// <summary>
@@ -251,7 +260,7 @@ namespace Microsoft.Scripting.Hosting {
         public ScriptScope CreateScope(IDynamicMetaObjectProvider storage) {
             ContractUtils.RequiresNotNull(storage, "storage");
 
-            return new ScriptScope(this, new Scope(storage));
+            return new ScriptScope(this, _language.CreateScope(storage));
         }
 
         /// <summary>

--- a/Runtime/Microsoft.Scripting/Runtime/LanguageContext.cs
+++ b/Runtime/Microsoft.Scripting/Runtime/LanguageContext.cs
@@ -76,8 +76,36 @@ namespace Microsoft.Scripting.Runtime {
 
         #region Scope
 
+        /// <summary>
+        /// Gets the scope associated with a file, or null if none was available
+        /// </summary>
         public virtual Scope GetScope(string path) {
             return null;
+        }
+
+        /// <summary>
+        /// Creates a new ScriptScope using the default storage container
+        /// </summary>
+        public virtual Scope CreateScope() {
+            return new Scope();
+        }
+                
+        /// <summary>
+        /// Creates a new ScriptScope whose storage contains the provided dictionary of objects
+        /// 
+        /// Accesses to the ScriptScope will turn into get,set, and delete members against this dictionary
+        /// </summary>
+        public virtual Scope CreateScope(IDictionary<string, object> dictionary) {
+            return new Scope(dictionary);
+        }
+        
+        /// <summary>
+        /// Creates a new ScriptScope whose storage is an arbitrary object.
+        /// 
+        /// Accesses to the ScriptScope will turn into get, set, and delete members against the object.
+        /// </summary>
+        public virtual Scope CreateScope(IDynamicMetaObjectProvider storage) {
+            return new Scope(storage);
         }
 
         // TODO: remove

--- a/Runtime/Microsoft.Scripting/Runtime/ScriptCode.cs
+++ b/Runtime/Microsoft.Scripting/Runtime/ScriptCode.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Scripting {
         }
 
         public virtual Scope CreateScope() {
-            return new Scope();
+            return _sourceUnit.LanguageContext.CreateScope();
         }
 
         public virtual object Run() {


### PR DESCRIPTION
# Reasoning

Certain languages may have need, or preference, for a certain type of backing store for scopes that they create. In the current implementation, it is the responsibility of the user to ensure that scopes are passed to all execution methods which make use of this backing store type. This introduces the possibility of a user attempting to make use of functionality which is only available when this backing store is implemented, without having provided a scope which makes use of this backing store.
# Solution

The solution is the allow each LanguageContext to control the creation of its default Scope object, thus providing languages with the ability to control what type of backing store is used, as well as what variables are initially available from a scope. This is done by providing virtual methods on the LanguageContext class which in their default state behave the same as the current implementation; and the modification of methods which are responsible for creating scopes to point to the LanguageContext, requesting that it create the scopes for them.
# State

Current implementation changes are non-breaking for existing implementations (insofar as that all unit tests run successfully), and provides the ability for a LanguageContext to handle the initialization of any Scope objects which are used by the DLR.
## Duplicate Reason

This is a duplicate of Pull Request 80, fixing the encoding issue which caused the entire file to be replaced in the last commit. (Thanks GitHub...) This commit will only change the relevant lines in each file.

[CodePlex Discussion](http://dlr.codeplex.com/discussions/395839)
