### PR TITLE
Get IronRuby `require` to work with Mono

### DIFF
--- a/Languages/Ruby/StdLib/ruby/1.9.1/rubygems/requirement.rb
+++ b/Languages/Ruby/StdLib/ruby/1.9.1/rubygems/requirement.rb
@@ -10,10 +10,10 @@ class Gem::Requirement
   OPS = { #:nodoc:
     "="  =>  lambda { |v, r| v == r },
     "!=" =>  lambda { |v, r| v != r },
-    ">"  =>  lambda { |v, r| v > r  },
-    "<"  =>  lambda { |v, r| v < r  },
     ">=" =>  lambda { |v, r| v >= r },
     "<=" =>  lambda { |v, r| v <= r },
+    ">"  =>  lambda { |v, r| v > r  },
+    "<"  =>  lambda { |v, r| v < r  },
     "~>" =>  lambda { |v, r| v = v.release; v >= r && v < r.bump }
   }
 


### PR DESCRIPTION
Because of [this bug](https://bugzilla.xamarin.com/show_bug.cgi?id=2770) in the Mono regex implementation, it is not possible to `require` anything when using IronRuby compiled with Mono.

Luckily it is trivial to work around the issue, all that needs to be done is to change the order in which the different operators are matched.
