### PR TITLE
DocBuilder exception fixed (when open generic type is used)

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/Types/DocBuilder.cs
+++ b/Languages/IronPython/IronPython/Runtime/Types/DocBuilder.cs
@@ -326,7 +326,7 @@ namespace IronPython.Runtime.Types {
                 paramDoc.Add(
                     new ParameterDoc(
                         pi.Name ?? "",  // manufactured methods, such as string[].ctor(int) can have no parameter names.
-                        GetPythonTypeName(pi.ParameterType),
+                        pi.ParameterType.IsGenericParameter ? pi.ParameterType.Name : GetPythonTypeName(pi.ParameterType),
                         paramDocString,
                         flags
                     )


### PR DESCRIPTION
**doc** throws exception if it encounter open generic type. Proposal is to just use name in such case. E.g. if we have following code in LibB dll:

```
namespace Test
{
    public class ValidGeneric<T>
    {
        public ValidGeneric(T value) {}
    }

    public class Generic<T> where T : IEquatable<T>
    {
        public Generic(T value) {}
    }
}
```

and python code is:

```
import clr
clr.AddReference("LibB")
from Test import ValidGeneric
print ValidGeneric.__doc__
from Test import Generic
print Generic.__doc__
```

current behavior will be

<pre>
ValidGeneric[T](value: T)

Traceback (most recent call last):
  File "test.py", line 6, in <module>
SystemError: Method must be called on a Type for which Type.IsGenericParameter is false.
</pre>


After fix:

<pre>
ValidGeneric[T](value: T)

Generic[T](value: T)
</pre>
