### PR TITLE
dictproxy iteration does not yield descriptors

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/Types/PythonType.cs
+++ b/Languages/IronPython/IronPython/Runtime/Types/PythonType.cs
@@ -1955,12 +1955,12 @@ type(name, bases, dict) -> creates a new type instance with the given name, base
                     if (TryLookupSlot(context, x, out dts)) {
                         //??? why check for DTVS?
                         object val;
-                        if (dts.TryGetValue(context, null, this, out val)) {
-                            if (dts is PythonTypeUserDescriptorSlot) {
-                                dict[x] = val;
-                            } else {
-                                dict[x] = dts;
-                            }
+                        if (dts is PythonTypeUserDescriptorSlot) {
+                            dict[x] = ((PythonTypeUserDescriptorSlot) dts).Value;
+                        } else if (dts.TryGetValue(context, null, this, out val)) {
+                            dict[x] = val;
+                        } else {
+                            dict[x] = dts;
                         }
                     }
                 }


### PR DESCRIPTION
Descriptors are omitted from dictproxy iteration.  See ipy console session:

```
IronPython 2.7.3 (2.7.0.40) on Mono 4.0.30319.17020 (64-bit)
Type "help", "copyright", "credits" or "license" for more information.
>>> class Descriptor(object):
...  def __get__(self, instance, owner): return instance.x    
... 
>>> class X(object): a = Descriptor()
... 
>>> X.__dict__
<dictproxy object at 0x000000000000003E>
>>> X.__dict__['a']
<Descriptor object at 0x000000000000003D>
>>> X.__dict__.keys()
['__doc__', '__weakref__', '__dict__', '__module__']
```

The expected behaviour is that descriptors would appear in dictproxy iteration.
