### PR TITLE
fixed %f formatting issues in datetime.strptime and datetime.strftime

### DIFF
--- a/Languages/IronPython/IronPython.Modules/datetime.cs
+++ b/Languages/IronPython/IronPython.Modules/datetime.cs
@@ -1105,10 +1105,8 @@ namespace IronPython.Modules {
             }
 
             public static datetime strptime(CodeContext/*!*/ context, string date_string, string format) {
-                var res = PythonTime._strptime(context, date_string, format, true) as datetime;
-                if(res == null)
-                    throw PythonOps.ValueError("time.strptime returned an invalid value.");
-                return res;
+                var packed = PythonTime._strptime(context, date_string, format);
+                return new datetime((DateTime)packed[0]);
             }
 
             #region IRichComparable Members

--- a/Languages/IronPython/IronPython.Modules/time.cs
+++ b/Languages/IronPython/IronPython.Modules/time.cs
@@ -192,10 +192,12 @@ namespace IronPython.Modules {
         }
 
         public static object strptime(CodeContext/*!*/ context, string @string, string format) {
-            return _strptime(context, @string, format, false);
+            var packed = _strptime(context, @string, format);
+            return GetDateTimeTuple((DateTime)packed[0], (DayOfWeek?)packed[1]);
         }
-
-        public static object _strptime(CodeContext/*!*/ context, string @string, string format, bool isDatetime) {
+        
+        // returns object array containing 2 elements: DateTime and DayOfWeek 
+        internal static object[] _strptime(CodeContext/*!*/ context, string @string, string format) {
             bool postProc;
             FoundDateComponents foundDateComp;
             List<FormatInfo> formatInfo = PythonFormatToCLIFormat(format, true, out postProc, out foundDateComp);
@@ -219,33 +221,40 @@ namespace IronPython.Modules {
                     throw PythonOps.ValueError("cannot parse %j, %W, or %U w/ other values");
                 }
             } else {
-                string[] formats = new string[formatInfo.Count];
+                var fIdx = -1;
+                string[] formatParts = new string[formatInfo.Count];
                 for (int i = 0; i < formatInfo.Count; i++) {
                     switch (formatInfo[i].Type) {
-                        case FormatInfoType.UserText: formats[i] = "'" + formatInfo[i].Text + "'"; break;
-                        case FormatInfoType.SimpleFormat: formats[i] = formatInfo[i].Text; break;
+                        case FormatInfoType.UserText: formatParts[i] = "'" + formatInfo[i].Text + "'"; break;
+                        case FormatInfoType.SimpleFormat: formatParts[i] = formatInfo[i].Text; break;
                         case FormatInfoType.CustomFormat:
+                            if (formatInfo[i].Text == "f") {
+                                fIdx = i;
+                            }
                             // include % if we only have one specifier to mark that it's a custom
                             // specifier
                             if (formatInfo.Count == 1 && formatInfo[i].Text.Length == 1) {
-                                formats[i] = "%" + formatInfo[i].Text;
+                                formatParts[i] = "%" + formatInfo[i].Text;
                             } else {
-                                formats[i] = formatInfo[i].Text;
+                                formatParts[i] = formatInfo[i].Text;
                             }
                             break;
                     }
                 }
+                var formats =
+                    fIdx == -1 ? new [] { String.Join("", formatParts) } : ExpandMicrosecondFormat(fIdx, formatParts);
                 try {
                     if (!StringUtils.TryParseDateTimeExact(@string,
-                        String.Join("", formats),
+                        formats,
                         PythonLocale.GetLocaleInfo(context).Time.DateTimeFormat,
                         DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.NoCurrentDateDefault,
                         out res)) {
-                        // If TryParseExact fails, fall back to DateTime.Parse which does a better job in some cases...
-                        res = DateTime.Parse(@string, PythonLocale.GetLocaleInfo(context).Time.DateTimeFormat);
+                        throw PythonOps.ValueError("time data does not match format" + Environment.NewLine + 
+                            "data=" + @string + ", fmt=" + format + ", to: " + formats[0]);
                     }
                 } catch (FormatException e) {
-                    throw PythonOps.ValueError(e.Message + Environment.NewLine + "data=" + @string + ", fmt=" + format + ", to: " + String.Join("", formats));
+                    throw PythonOps.ValueError(e.Message + Environment.NewLine + 
+                        "data=" + @string + ", fmt=" + format + ", to: " + formats[0]);
                 }
             }
 
@@ -257,10 +266,19 @@ namespace IronPython.Modules {
             if ((foundDateComp & FoundDateComponents.Year) == 0) {
                 res = new DateTime(1900, res.Month, res.Day, res.Hour, res.Minute, res.Second, res.Millisecond, res.Kind);
             }
-            if (isDatetime) {
-                return new PythonDateTime.datetime(res);
-            } 
-            return GetDateTimeTuple(res, dayOfWeek);
+
+            return new object[] { res, dayOfWeek };
+        }
+
+        private static string[] ExpandMicrosecondFormat(int fIdx, string [] formatParts) {
+            // for %f number of digits can be anything between 1 and 6
+            string[] formats = new string[6];
+            formats[0] = String.Join("", formatParts);
+            for (var i = 1; i < 6; i++) {
+                formatParts[fIdx] = new String('f', i+1);
+                formats[i] = String.Join("", formatParts);
+            }
+            return formats;
         }
 
         internal static string strftime(CodeContext/*!*/ context, string format, DateTime dt, int? microseconds) {
@@ -479,7 +497,7 @@ namespace IronPython.Modules {
                             break;
                         case 'f':
                             if (forParse) {
-                                newFormat.Add(new FormatInfo(FormatInfoType.CustomFormat, "ffffff")); 
+                                newFormat.Add(new FormatInfo(FormatInfoType.CustomFormat, "f")); 
                             } else {
                                 postProcess = true;
                                 newFormat.Add(new FormatInfo(FormatInfoType.UserText, "%f"));
@@ -536,9 +554,7 @@ namespace IronPython.Modules {
         internal static PythonTuple GetDateTimeTuple(DateTime dt, DayOfWeek? dayOfWeek, PythonDateTime.tzinfo tz) {
             int last = -1;
 
-            if (tz == null) {
-                last = -1;
-            } else {
+            if (tz != null) {
                 PythonDateTime.timedelta delta = tz.dst(dt);
                 PythonDateTime.ThrowIfInvalid(delta, "dst");
                 if (delta == null) {

--- a/Languages/IronPython/Tests/test_datetime.py
+++ b/Languages/IronPython/Tests/test_datetime.py
@@ -15,7 +15,8 @@
 #####################################################################################
 
 import unittest
-from datetime import datetime
+from datetime import datetime, date
+import time
 from test import test_support
 
 class TestDatetime(unittest.TestCase):
@@ -31,13 +32,33 @@ class TestDatetime(unittest.TestCase):
         self.assertEquals(d, datetime(2013, 11, 29, 16, 38, 12, 507042))
 
     def test_strptime_3(self):
-        d = datetime.strptime("2013-11-29T16:38:12.507", "%Y-%m-%dT%H:%M:%S.%f")
+        d = datetime.strptime("2013-11-29T16:38:12.5070", "%Y-%m-%dT%H:%M:%S.%f")
         self.assertEquals(d, datetime(2013, 11, 29, 16, 38, 12, 507000))
 
     def test_strptime_4(self):
+        d = datetime.strptime("2013-11-29T16:38:12.507", "%Y-%m-%dT%H:%M:%S.%f")
+        self.assertEquals(d, datetime(2013, 11, 29, 16, 38, 12, 507000))
+
+    def test_strptime_5(self):
+        d = datetime.strptime("2013-11-29T16:38:12.50", "%Y-%m-%dT%H:%M:%S.%f")
+        self.assertEquals(d, datetime(2013, 11, 29, 16, 38, 12, 500000))
+
+    def test_strptime_6(self):
         d = datetime.strptime("2013-11-29T16:38:12.5", "%Y-%m-%dT%H:%M:%S.%f")
         self.assertEquals(d, datetime(2013, 11, 29, 16, 38, 12, 500000))
 
+    def test_strptime_7(self):
+        d = datetime.strptime("11-29T16:38:12.123", "%m-%dT%H:%M:%S.%f")
+        self.assertEquals(d, datetime(1900, 11, 29, 16, 38, 12, 123000))
+
+    def test_strptime_8(self):
+        d = datetime.strptime("11-29T16:38:12.123", "%m-%dT%H:%M:%S.%f")
+        self.assertEquals(d, datetime(1900, 11, 29, 16, 38, 12, 123000))
+
+    def test_strptime_9(self):
+        d = datetime.strptime('Monday 11. March 2002', "%A %d. %B %Y")
+        self.assertEquals(d, datetime(2002, 3, 11, 0, 0))
+    
     def test_strftime_1(self):
         d = datetime(2013, 11, 29, 16, 38, 12, 507000)
         self.assertEquals(d.strftime("%Y-%m-%dT%H:%M:%S.%f"), "2013-11-29T16:38:12.507000")
@@ -50,6 +71,40 @@ class TestDatetime(unittest.TestCase):
         # cp32215
         d = datetime(2012,2,8,4,5,6,12314)
         self.assertEquals(d.strftime('%f'), "012314")
+
+    def test_cp23965(self):
+        # this is locale dependant and assumes test will be run under en_US
+        self.assertEquals(date(2013, 11, 30).strftime("%Y %A %B"), "2013 Saturday November")
+        self.assertEquals(date(2013, 11, 30).strftime("%y %a %b"), "13 Sat Nov")
+
+    def test_invalid_strptime(self):
+        # cp30047
+        self.assertRaises(ValueError, datetime.strptime, "9 August", "%B %d")
+        d = datetime.strptime("9 August", "%d %B")
+        self.assertEquals(d, datetime(1900, 8, 9, 0, 0))
+
+    def test_strptime_day_of_week(self):
+        t = time.strptime("2013", "%Y")
+        self.assertEqual(t, (2013, 1, 1, 0, 0, 0, 1, 1, -1)) 
+        t = time.strptime("2013-11", "%Y-%m")
+        self.assertEqual(t, (2013, 11, 1, 0, 0, 0, 4, 305, -1))
+        t = time.strptime("2013-11-29", "%Y-%m-%d")
+        self.assertEqual(t, (2013, 11, 29, 0, 0, 0, 4, 333, -1))
+        t = time.strptime("2013-11-29T16", "%Y-%m-%dT%H")
+        self.assertEqual(t, (2013, 11, 29, 16, 0, 0, 4, 333, -1))
+        t = time.strptime("2013-11-29T16:38", "%Y-%m-%dT%H:%M")
+        self.assertEqual(t, (2013, 11, 29, 16, 38, 0, 4, 333, -1))
+        t = time.strptime("2013-11-29T16:38:12", "%Y-%m-%dT%H:%M:%S")
+        self.assertEqual(t, (2013, 11, 29, 16, 38, 12, 4, 333, -1))
+
+        t = time.strptime("2013-11-29 Friday", "%Y-%m-%d %A")
+        self.assertEqual(t, (2013, 11, 29, 0, 0, 0, 4, 333, -1))
+        t = time.strptime("2013-11-29T16 Friday", "%Y-%m-%dT%H %A")
+        self.assertEqual(t, (2013, 11, 29, 16, 0, 0, 4, 333, -1))
+        t = time.strptime("2013-11-29T16:38 Friday", "%Y-%m-%dT%H:%M %A")
+        self.assertEqual(t, (2013, 11, 29, 16, 38, 0, 4, 333, -1))
+        t = time.strptime("2013-11-29T16:38:12 Friday", "%Y-%m-%dT%H:%M:%S %A")
+        self.assertEqual(t, (2013, 11, 29, 16, 38, 12, 4, 333, -1))
 
 
 def test_main():

--- a/Runtime/Microsoft.Dynamic/Utils/StringUtils.cs
+++ b/Runtime/Microsoft.Dynamic/Utils/StringUtils.cs
@@ -226,6 +226,10 @@ namespace Microsoft.Scripting.Utils {
             return DateTime.TryParseExact(s, format, provider, style, out result);
         }
 
+        public static bool TryParseDateTimeExact(string s, string[] formats, IFormatProvider provider, DateTimeStyles style, out DateTime result) {
+            return DateTime.TryParseExact(s, formats, provider, style, out result);
+        }
+
         public static bool TryParseDate(string s, IFormatProvider provider, DateTimeStyles style, out DateTime result) {
             return DateTime.TryParse(s, provider, style, out result);
         }


### PR DESCRIPTION
strptime acts diffrently depending on module it is called from (dateime vs. time)
added very basic test_datetime.py
fixed cp34706 and cp32215
