### PR TITLE
Enable access to Protected Events from Subclass

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/Types/PythonTypeInfo.cs
+++ b/Languages/IronPython/IronPython/Runtime/Types/PythonTypeInfo.cs
@@ -602,6 +602,23 @@ namespace IronPython.Runtime.Types {
                 // these members are visible but only accept derived types.
                 foreach (Type t in binder.GetContributingTypes(type)) {
                     foreach (MemberInfo mi in t.GetMembers(BindingFlags.Static | BindingFlags.Instance | BindingFlags.NonPublic)) {
+                        if (mi.MemberType == MemberTypes.Method) {
+                            MethodInfo meth = (MethodInfo)mi;
+
+                            if (meth.IsSpecialName) {
+                                if (meth.IsDefined(typeof(PropertyMethodAttribute), true)) {
+                                    if (ProtectedOnly(mi)) {
+                                        if (meth.Name.StartsWith("Get") || meth.Name.StartsWith("Set")) {
+                                            yield return meth.Name.Substring(3);
+                                        } else {
+                                            Debug.Assert(meth.Name.StartsWith("Delete"));
+                                            yield return meth.Name.Substring(6);
+                                        }
+                                    }
+                                }
+                                continue;
+                            }
+                        }
                         if (ProtectedOnly(mi)) {
                             yield return mi.Name;
                         }
@@ -1819,6 +1836,9 @@ namespace IronPython.Runtime.Types {
                     return ((FieldInfo)input).IsProtected();
                 case MemberTypes.NestedType:
                     return ((Type)input).IsProtected();
+                case MemberTypes.Event:
+                    MethodInfo emi = (((EventInfo)input).GetAddMethod(true));
+                    return emi != null && ProtectedOnly(emi);
                 default:
                     return false;
             }

--- a/Languages/IronPython/IronPython/Runtime/Types/ReflectedEvent.cs
+++ b/Languages/IronPython/IronPython/Runtime/Types/ReflectedEvent.cs
@@ -181,7 +181,9 @@ namespace IronPython.Runtime.Types {
                     add = CompilerHelpers.TryGetCallableMethod(_instance.GetType(), add);
                 }
 
-                if (CompilerHelpers.IsVisible(add) || context.LanguageContext.DomainManager.Configuration.PrivateBinding) {
+                if (CompilerHelpers.IsVisible(add)
+                    || (add.IsProtected() /*todo: validate current context is in family*/ )
+                    || context.LanguageContext.DomainManager.Configuration.PrivateBinding) {
                     _event.Tracker.AddHandler(_instance, func, context.LanguageContext.DelegateCreator);
                 } else {
                     throw new TypeErrorException("Cannot add handler to a private event.");
@@ -205,10 +207,12 @@ namespace IronPython.Runtime.Types {
                 }
 
                 MethodInfo remove = _event.Tracker.GetRemoveMethod();
-                if (CompilerHelpers.IsVisible(remove) || context.LanguageContext.DomainManager.Configuration.PrivateBinding) {
+                if (CompilerHelpers.IsVisible(remove)
+                    || (remove.IsProtected() /*todo: validate current context is in family*/ )
+                    || context.LanguageContext.DomainManager.Configuration.PrivateBinding) {
                     _event.Tracker.RemoveHandler(_instance, func, PythonContext.GetContext(context).EqualityComparer);
                 } else {
-                    throw new TypeErrorException("Cannot add handler to a private event.");
+                    throw new TypeErrorException("Cannot remove handler from a private event.");
                 }
                 return this;
             }

--- a/Languages/IronPython/IronPythonTest/Events.cs
+++ b/Languages/IronPython/IronPythonTest/Events.cs
@@ -82,5 +82,20 @@ namespace IronPythonTest {
         public static void AddSetMarkerDelegateToStaticTest() {
             StaticTest += new EventTestDelegate(StaticSetMarker);
         }
+
+        public void FireProtectedTest() {
+            if (OnProtectedEvent != null) OnProtectedEvent(this, EventArgs.Empty);
+            if (ExplicitProtectedEvent != null) ExplicitProtectedEvent(this, EventArgs.Empty);
+        }
+
+        protected event EventHandler OnProtectedEvent;
+
+        private EventHandler ExplicitProtectedEvent;
+
+        public event EventHandler OnExplicitProtectedEvent {
+            add { ExplicitProtectedEvent += value; }
+            remove { ExplicitProtectedEvent -= value; }
+        }
+
     }
 }

--- a/Languages/IronPython/Tests/test_protected.py
+++ b/Languages/IronPython/Tests/test_protected.py
@@ -98,6 +98,133 @@ def test_override():
     AreEqual(a.CallProtected(), 'MyInherited Override')
     AreEqual(a.ProtectedProperty, "MyInherited.Protected")
     AreEqual(a.CallProtectedProp(), "MyInherited.Protected")
+
+def test_events():
     
+    # can't access protected methods directly
+    a = Events()
+    
+    # they are present...
+    Assert('OnProtectedEvent' in dir(a))
+    Assert('OnExplicitProtectedEvent' in dir(a))
+    Assert(hasattr(a, 'OnProtectedEvent'))
+    Assert(hasattr(a, 'OnExplicitProtectedEvent'))
+    
+    # they should not be present
+    Assert('add_OnProtectedEvent' not in dir(a))
+    Assert('remove_OnProtectedEvent' not in dir(a))
+    Assert('add_OnExplicitProtectedEvent' not in dir(a))
+    Assert('remove_OnExplicitProtectedEvent' not in dir(a))
+
+    # should not be present as its private
+    Assert('ExplicitProtectedEvent' not in dir(a))
+    
+    def OuterEventHandler(source, args):
+        global called
+        called = True
+
+    global called
+    # Testing accessing protected Events fails.  
+    # TODO: Currently adding non-protected events do not generate errors due to lack of context checking
+    called = False
+    #AssertErrorWithMessage(TypeError, "Cannot add handler to a private event.", lambda : a.OnProtectedEvent += OuterEventHandler)
+    a.OnProtectedEvent += OuterEventHandler
+    a.FireProtectedTest()
+    a.OnProtectedEvent -= OuterEventHandler
+    #AssertErrorWithMessage(TypeError, "Cannot remove handler to a private event.", lambda : a.OnProtectedEvent -= OuterEventHandler)
+    #AreEqual(called, False) # indicates that event fired and set value which should not be allowed
+    
+    called = False
+    #AssertErrorWithMessage(TypeError, "Cannot add handler to a private event.", lambda : a.OnExplicitProtectedEvent += OuterEventHandler)
+    a.OnExplicitProtectedEvent += OuterEventHandler
+    a.FireProtectedTest()
+    a.OnExplicitProtectedEvent -= OuterEventHandler
+    #AssertErrorWithMessage(TypeError, "Cannot remove handler to a private event.", lambda : a.OnExplicitProtectedEvent -= OuterEventHandler)
+    #AreEqual(called, False)
+    
+    
+    class MyInheritedEvents(Events):
+        called3 = False
+        called4 = False
+        
+        def __init__(self):
+            self.called1 = False
+            self.called2 = False
+            
+        def InnerEventHandler1(self, source, args):
+            self.called1 = True
+            
+        def InnerEventHandler2(self, source, args):
+            self.called2 = True
+            
+        def RegisterEventsInstance(self):
+            self.OnProtectedEvent += OuterEventHandler
+            self.OnProtectedEvent += self.InnerEventHandler1
+            self.OnExplicitProtectedEvent += self.InnerEventHandler2
+            
+        def UnregisterEventsInstance(self):
+            self.OnProtectedEvent -= self.InnerEventHandler1
+            self.OnExplicitProtectedEvent -= self.InnerEventHandler2
+
+        @classmethod
+        def InnerEventHandler3(cls, source, args):
+            cls.called3 = True
+            
+        @classmethod
+        def InnerEventHandler4(cls, source, args):
+            cls.called4 = True
+            
+        @classmethod        
+        def RegisterEventsStatic(cls, events):
+            events.OnProtectedEvent += OuterEventHandler
+            events.OnProtectedEvent += cls.InnerEventHandler3
+            events.OnExplicitProtectedEvent += cls.InnerEventHandler4
+            
+        @classmethod
+        def UnregisterEventsStatic(cls, events):
+            events.OnProtectedEvent -= OuterEventHandler
+            events.OnProtectedEvent -= cls.InnerEventHandler3
+            events.OnExplicitProtectedEvent -= cls.InnerEventHandler4
+    
+    # validate instance methods work
+    b = MyInheritedEvents()
+    called = b.called1 = b.called2 = False
+    b.RegisterEventsInstance()
+    b.FireProtectedTest()
+    AreEqual(called, True)
+    AreEqual(b.called1, True)
+    AreEqual(b.called2, True)
+
+    # validate theat static methods work
+    c = MyInheritedEvents()
+    called = MyInheritedEvents.called3 = MyInheritedEvents.called4 = False
+    MyInheritedEvents.RegisterEventsStatic(c)
+    c.FireProtectedTest()
+    MyInheritedEvents.UnregisterEventsStatic(c)
+    AreEqual(called, True)
+    AreEqual(MyInheritedEvents.called3, True)
+    AreEqual(MyInheritedEvents.called4, True)
+
+    class WrapEvents(Events): 
+        @classmethod        
+        def RegisterEventsStatic(cls, events):
+            events.OnProtectedEvent += OuterEventHandler
+        @classmethod
+        def UnregisterEventsStatic(cls, events):
+            events.OnProtectedEvent -= OuterEventHandler
+    
+    # baseline empty test 
+    d = Events()
+    called = False
+    d.FireProtectedTest()
+    AreEqual(called, False)
+        
+    # use wrapevents to bypass protection
+    called = False
+    WrapEvents.RegisterEventsStatic(d)
+    d.FireProtectedTest()
+    WrapEvents.UnregisterEventsStatic(d)
+    AreEqual(called, True)
+
 
 run_test(__name__)


### PR DESCRIPTION
Alter event handling to show protected events as objects rather than exposing add_ and remove_ methods which cannot be used.  Effectively mimic StandardResolver behavior in ProtectedMemberResolver with additional protection tests against the add method.

Unfortunately this is not a complete solution as protected events are exposed to all contexts because I cannot resolve how to perform a test for current executing frame type to check if its a subclass of the class with the protected event.
