### PR TITLE
https://ironruby.codeplex.com/workitem/7406

### DIFF
--- a/Languages/Ruby/Ruby/Builtins/RubyEncoding.cs
+++ b/Languages/Ruby/Ruby/Builtins/RubyEncoding.cs
@@ -94,6 +94,14 @@ namespace IronRuby.Builtins {
             _isAsciiIdentity = AsciiIdentity(encoding);
         }
 
+        /// <summary>
+        /// Default construtor (ASCII)
+        /// MEMO: exists mainly for Marshal.load.
+        /// </summary>
+        protected RubyEncoding()
+            : this(CreateEncoding(CodePageAscii, false), CreateEncoding(CodePageAscii, true), -2) {
+        }
+
         public override int GetHashCode() {
             return _ordinal;
         }


### PR DESCRIPTION
Added default constructor for Encoding (mainly for Marshal.load).
