### PR TITLE
Fix broken command line in the `Makefile`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@
 all: ironpython
 
 ironpython:
-	xbuild Build.proj /t:Build /p:Mono=true;BaseConfiguration=Debug
+	xbuild Build.proj /t:Build "/p:Mono=true;BaseConfiguration=Debug"
 
 ironpython-release:
-	xbuild Build.proj /t:Build /p:Mono=true;BaseConfiguration=Release
+	xbuild Build.proj /t:Build "/p:Mono=true;BaseConfiguration=Release"
 
 testrunner:
-	xbuild Test/TestRunner/TestRunner.sln	
+	xbuild Test/TestRunner/TestRunner.sln
 
 test-ipy: ironpython testrunner
 	mono Test/TestRunner/TestRunner/bin/Debug/TestRunner.exe Test/IronPython.tests /all


### PR DESCRIPTION
The argument including ';' should be quoted because the it will be interpreted as the end of the line by the ordinary UNIX shells.
