### PR TITLE
fixed cp35135 - re extension flag can contain multiple letters

### DIFF
--- a/Languages/IronPython/IronPython.Modules/re.cs
+++ b/Languages/IronPython/IronPython.Modules/re.cs
@@ -1037,19 +1037,28 @@ namespace IronPython.Modules {
                                                 pattern = pattern.Remove(nameIndex, 1);
                                             }
                                             break;
-                                        case 'i': res.Options |= RegexOptions.IgnoreCase; break;
+                                        case 'i':
+                                            res.Options |= RegexOptions.IgnoreCase;
+                                            RemoveOption(ref pattern, ref nameIndex);
+                                            break;
                                         case 'L':
                                             res.Options &= ~(RegexOptions.CultureInvariant);
                                             RemoveOption(ref pattern, ref nameIndex);
                                             break;
-                                        case 'm': res.Options |= RegexOptions.Multiline; break;
-                                        case 's': res.Options |= RegexOptions.Singleline; break;
+                                        case 'm': res.Options |= RegexOptions.Multiline;
+                                            RemoveOption(ref pattern, ref nameIndex);
+                                            break;
+                                        case 's': res.Options |= RegexOptions.Singleline;
+                                            RemoveOption(ref pattern, ref nameIndex);
+                                            break;
                                         case 'u':
                                             // specify unicode; not relevant and not valid under .NET as we're always unicode
                                             // -- so the option needs to be removed
                                             RemoveOption(ref pattern, ref nameIndex);
                                             break;
-                                        case 'x': res.Options |= RegexOptions.IgnorePatternWhitespace; break;
+                                        case 'x': res.Options |= RegexOptions.IgnorePatternWhitespace;
+                                            RemoveOption(ref pattern, ref nameIndex);
+                                            break;
                                         case ':': break; // non-capturing
                                         case '=': break; // look ahead assertion
                                         case '<': break; // positive look behind assertion
@@ -1149,7 +1158,8 @@ namespace IronPython.Modules {
                 pattern = pattern.Remove(nameIndex - 2, 4);
                 nameIndex -= 2;
             } else {
-                pattern = pattern.Remove(nameIndex--, 1);
+                pattern = pattern.Remove(nameIndex, 1);
+                nameIndex -= 2;
             }
         }
 

--- a/Languages/IronPython/Tests/modules/io_related/re_test.py
+++ b/Languages/IronPython/Tests/modules/io_related/re_test.py
@@ -808,5 +808,10 @@ def test_cp35146():
     # re.compile returns cached instances
     AreEqual(re.compile('cp35146'), re.compile('cp35146'))
 
+def test_cp35135():
+    AreEqual(re.match(r"(?iu)aA", "aa").string, "aa")
+    AreEqual(re.match(r"(?iu)Aa", "aa").string, "aa")
+    AreEqual(re.match(r"(?iLmsux)Aa", "aa").string, "aa")
+
 #--MAIN------------------------------------------------------------------------        
 run_test(__name__)


### PR DESCRIPTION
all processed re extension flags are removed once converted to option

The semantic of the (?iLmsux) options in python apply to entire re. Once set, it can not be changed. https://docs.python.org/2/library/re.html#regular-expression-syntax

In case of c# regex  (?imnsx-imnsx) options can be turned on/off and apply until the end of enclosing group or subexpression only. http://msdn.microsoft.com/en-us/library/x044wc7s%28v=vs.100%29.aspx
Since the options are detected and captured, there is no point of keeping them in expression.
