### PR TITLE
fixed cp34849

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/Exceptions/TraceBack.cs
+++ b/Languages/IronPython/IronPython/Runtime/Exceptions/TraceBack.cs
@@ -17,6 +17,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 using Microsoft.Scripting;
 using Microsoft.Scripting.Runtime;
@@ -66,6 +67,24 @@ namespace IronPython.Runtime.Exceptions {
 
         internal void SetLine(int lineNumber) {
             _line = lineNumber;
+        }
+
+        /// <summary>
+        /// returns string containing human readable representation of traceback
+        /// </summary>
+        internal string Extract() {
+            var sb = new StringBuilder();
+            var tb = this;
+            while (tb != null) {
+                var f = tb._frame;
+                var lineno = tb._line;
+                var co = f.f_code;
+                var filename = co.co_filename;
+                var name = co.co_name;
+                sb.AppendFormat("  File \"{0}\", line {1}, in {2}{3}", filename, lineno, name, Environment.NewLine);
+                tb = tb._next;
+            }
+            return sb.ToString();
         }
     }
 

--- a/Languages/IronPython/IronPython/Runtime/PythonContext.cs
+++ b/Languages/IronPython/IronPython/Runtime/PythonContext.cs
@@ -1678,6 +1678,10 @@ namespace IronPython.Runtime {
                 printedHeader = true;
             }
 
+            var traceback = e.GetTraceBack();
+            if (traceback != null) {
+                return result + traceback.Extract();
+            }
             var frames = PythonExceptions.GetDynamicStackFrames(e);
             for (int i = frames.Length - 1; i >= 0; i--) {
                 var frame = frames[i];


### PR DESCRIPTION
top level exception reporting uses existing exception traceback
adjusted test cases to account for extra new line - cp34871
disabled test for cp33123 - it can be only run manually
