### PR TITLE
added broken but importable version of multiprocessing - cp34959

### DIFF
--- a/External.LCA_RESTRICTED/Languages/IronPython/27/Lib/multiprocessing/__init__.py
+++ b/External.LCA_RESTRICTED/Languages/IronPython/27/Lib/multiprocessing/__init__.py
@@ -81,7 +81,11 @@ class AuthenticationError(ProcessError):
     pass
 
 # This is down here because _multiprocessing uses BufferTooShort
-import _multiprocessing
+try:
+    # IronPython does not provide _multiprocessing
+    import _multiprocessing
+except ImportError:
+    pass
 
 #
 # Definitions not depending on native semaphores

--- a/External.LCA_RESTRICTED/Languages/IronPython/27/Lib/multiprocessing/process.py
+++ b/External.LCA_RESTRICTED/Languages/IronPython/27/Lib/multiprocessing/process.py
@@ -306,7 +306,7 @@ class _MainProcess(Process):
         self._popen = None
         self._counter = itertools.count(1)
         self._children = set()
-        self._authkey = AuthenticationString(os.urandom(32))
+        self._authkey = AuthenticationString(bytes(os.urandom(32), 'latin-1'))
         self._tempdir = None
 
 _current_process = _MainProcess()

--- a/Languages/IronPython/StdLib/StdLib.pyproj
+++ b/Languages/IronPython/StdLib/StdLib.pyproj
@@ -509,6 +509,20 @@
     <Content Include="$(StdLibPath)\ensurepip\_uninstall.py" />
     <Content Include="$(StdLibPath)\ensurepip\__init__.py" />
     <Content Include="$(StdLibPath)\ensurepip\__main__.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\connection.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\dummy\connection.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\dummy\__init__.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\forking.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\heap.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\managers.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\pool.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\process.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\queues.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\reduction.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\sharedctypes.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\synchronize.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\util.py" />
+    <Content Include="$(StdLibPath)\multiprocessing\__init__.py" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.targets"/>
 


### PR DESCRIPTION
This changes reduced number of modifications I had to do in ipython. I don't thing ipython did anything else than import, or at least my usage scenarios did not trigger real issues with multiprocessing.
