### PR TITLE
Fix Translate issue #27904, string comparison fix and updated test_bytes

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/ByteArray.cs
+++ b/Languages/IronPython/IronPython/Runtime/ByteArray.cs
@@ -139,7 +139,7 @@ namespace IronPython.Runtime {
         public int pop() {
             lock (this) {
                 if (Count == 0) {
-                    throw PythonOps.OverflowError("pop off of empty bytearray");
+                    throw PythonOps.IndexError("pop off of empty bytearray");
                 }
 
                 int res = _bytes[_bytes.Count - 1];
@@ -151,7 +151,7 @@ namespace IronPython.Runtime {
         public int pop(int index) {
             lock (this) {
                 if (Count == 0) {
-                    throw PythonOps.OverflowError("pop off of empty bytearray");
+                    throw PythonOps.IndexError("pop off of empty bytearray");
                 }
 
                 index = PythonOps.FixIndex(index, Count);
@@ -790,25 +790,27 @@ namespace IronPython.Runtime {
         }
 
         public ByteArray/*!*/ translate([BytesConversion]IList<byte>/*!*/ table) {
-            if (table == null) {
-                throw PythonOps.TypeError("expected bytearray or bytes, got NoneType");
-            }
-
+           
             lock (this) {
-                if (table.Count != 256) {
-                    throw PythonOps.ValueError("translation table must be 256 characters long");
-                } else if (Count == 0) {
-                    return CopyThis();
+                if (table != null) {
+                    if (table.Count != 256) {
+                        throw PythonOps.ValueError("translation table must be 256 characters long");
+                    }
+                    else if (Count == 0) {
+                        return CopyThis();
+                    }
                 }
 
                 return new ByteArray(_bytes.Translate(table, null));
             }
         }
 
+
         public ByteArray/*!*/ translate([BytesConversion]IList<byte>/*!*/ table, [BytesConversion]IList<byte>/*!*/ deletechars) {
-            if (table == null) {
+            if (table == null && deletechars == null) {
                 throw PythonOps.TypeError("expected bytearray or bytes, got NoneType");
-            } else if (deletechars == null) {
+            }
+            else if (deletechars == null) {
                 throw PythonOps.TypeError("expected bytes or bytearray, got None");
             }
             
@@ -1272,8 +1274,14 @@ namespace IronPython.Runtime {
                 return (IList<byte>)value;
             }
 
-            if (value is string || value is Extensible<string>) {
-                throw PythonOps.TypeError("unicode argument without an encoding");
+            var strValue = value as string;
+            if (strValue != null) {
+                return strValue.MakeByteArray();
+            }
+
+            var esValue = value as Extensible<string>;
+            if (esValue != null) {
+                return esValue.Value.MakeByteArray();
             }
 
             List<byte> ret = new List<byte>();
@@ -1408,7 +1416,14 @@ namespace IronPython.Runtime {
         }
 
         public override bool Equals(object other) {
-            IList<byte> bytes = other as IList<byte>;
+            IList<byte> bytes ;
+            if (other is string)
+                bytes = PythonOps.MakeBytes(((string)other).MakeByteArray());
+            else if (other is Extensible<string>)
+                bytes = PythonOps.MakeBytes(((Extensible<string>)other).Value.MakeByteArray());
+            else
+                bytes = other as IList<byte>;
+
             if (bytes == null || Count != bytes.Count) {
                 return false;
             } else if (Count == 0) {

--- a/Languages/IronPython/Tests/test_bytes.py
+++ b/Languages/IronPython/Tests/test_bytes.py
@@ -748,14 +748,10 @@ def test_translate():
     AreEqual(b'AAA'.translate(None, b'A'), b'')
     AreEqual(b'AAABBB'.translate(None, b'A'), b'BBB')
     AreEqual(b'AAA'.translate(None), b'AAA')
-    if is_ironpython: #http://ironpython.codeplex.com/workitem/27904
-        AssertError(TypeError, bytearray(b'AAA').translate, None, b'A')
-        AssertError(TypeError, bytearray(b'AAA').translate, None)
-    else:
-        AreEqual(bytearray(b'AAA').translate(None, b'A'),
-                 b'')
-        AreEqual(bytearray(b'AAA').translate(None),
-                 b'AAA')
+    AreEqual(bytearray(b'AAA').translate(None, b'A'),
+             b'')
+    AreEqual(bytearray(b'AAA').translate(None),
+             b'AAA')
 
     b = b'abc'    
     AreEqual(id(b.translate(None)), id(b))    
@@ -1397,10 +1393,12 @@ def test_zzz_cli_features():
         AreEqual(testType(b'').join([myList]), b'abc')
 
     # bytearray
+    '''
     AreEqual(bytearray(b'abc') == 'abc', False)
     if not is_net40:
         AreEqual(Microsoft.Scripting.IValueEquality.ValueEquals(bytearray(b'abc'), 'abc'), False)
-    
+    '''
+    AreEqual(bytearray(b'abc') == 'abc', True)
     AreEqual(b'abc'.IsReadOnly, True)
     AreEqual(bytearray(b'abc').IsReadOnly, False)
         
@@ -1452,5 +1450,8 @@ def test_bytes_hashing():
         #For now just make sure this doesn't throw
         temp = hashLib(bytearray(b'abc'))
         x.update(bytearray(b'abc'))
+
+def test_cp35493():
+    AreEqual(bytearray(u'\xde\xad\xbe\xef\x80'), bytearray(b'\xde\xad\xbe\xef\x80'))
 
 run_test(__name__)


### PR DESCRIPTION
Let's see if I did this correct. I pulled the latest ipy-2.7-maint and merged my changes into a new branch. It contains my code from the pull/213.  The changes are of the following
1. throw the appropriate exception for Pop verified with CPython 2.7.8
2. Fix the translate issue 27904 
3. string comparison fix issue 35470
4. Pulled changes from https://github.com/IronLanguages/main/pull/214. I wasn't sure if I would stomp on it. 
