### PR TITLE
changes to #23829, #23742, #23853, and implemented getservbyport and get...

### DIFF
--- a/Languages/IronPython/IronPython.Modules/socket.cs
+++ b/Languages/IronPython/IronPython.Modules/socket.cs
@@ -505,17 +505,14 @@ namespace IronPython.Modules {
                 + "is not specified (or 0), receive up to the size available in the given buffer.\n\n"
                 + "See recv() for documentation about the flags.\n"
                 )]
-            public int recv_into(MemoryView buffer, [DefaultParameterValue(0)]int nbytes, [DefaultParameterValue(0)]int flags){
+            public int recv_into(MemoryView buffer, [DefaultParameterValue(0)]int nbytes, [DefaultParameterValue(0)]int flags) {
                 int bytesRead;
                 byte[] byteBuffer = buffer.tobytes().ToByteArray();
-                try
-                {
+                try {
                     bytesRead = _socket.Receive(byteBuffer, (SocketFlags)flags);
                 }
-                catch (Exception e)
-                {
-                    if (_socket.SendTimeout == 0)
-                    {
+                catch (Exception e) {
+                    if (_socket.SendTimeout == 0) {
                         var s = new SocketException((int)SocketError.NotConnected);
                         throw PythonExceptions.CreateThrowable(error(_context), (int)SocketError.NotConnected, s.Message);
                     }
@@ -524,10 +521,7 @@ namespace IronPython.Modules {
 
                 }
 
-                for (int i = 0; i < bytesRead; i++)
-                {
-                    buffer[i] = byteBuffer[i];
-                }
+                buffer[new Slice(0, bytesRead)] = byteBuffer.Slice(new Slice(0, bytesRead));
                 return bytesRead;
 
             }
@@ -617,9 +611,7 @@ namespace IronPython.Modules {
                     throw MakeRecvException(e, SocketError.InvalidArgument);
                 }
 
-                for (int i = 0; i < byteBuffer.Length; i++){
-                    buffer[i] = byteBuffer[i];
-                }
+                buffer[new Slice(0, bytesRead)] = byteBuffer.Slice(new Slice(0, bytesRead));
                 PythonTuple remoteAddress = EndPointToTuple((IPEndPoint)remoteEP);
                 return PythonTuple.MakeTuple(bytesRead, remoteAddress);
             }


### PR DESCRIPTION
I pulled out my pull out socket changes from pull 213 into this socket_updates branch. It contains
Only the socket.cs file. I don't play with git alot so who knows if I did this right.

item# 23853
On socket.recv timeouts CPython throws a socket.error instead of socket.timeout exception. 
I didn't know how to access timeout from MakeException fuction so I check where the exception occurs at the recv function and raise a socket.error exception instead and the error message is similar to CPython 2.7.8

item# 23829

Change the exception thrown I throw PythonOps.ValueError("Timeout value out of range") instead of TypeError

item# 23742
I implemented a getservbyport and getservbyname (if approved below) which is called in the getnameinfo so it doesn't have to informce the NI_NUMERICSERV flag.
