### PR TITLE
address issue #17894 with the close method. I tested against test_socket...

### DIFF
--- a/Languages/IronPython/IronPython.Modules/socket.cs
+++ b/Languages/IronPython/IronPython.Modules/socket.cs
@@ -2239,8 +2239,9 @@ namespace IronPython.Modules {
             }
 
             public override void Close() {
-                if (PythonOps.HasAttr(DefaultContext.Default,_userSocket,"close"))
-                    DefaultContext.DefaultPythonContext.CallSplat(PythonOps.GetBoundAttr(DefaultContext.Default, _userSocket, "close"));
+                object closeObj;
+                if(PythonOps.TryGetBoundAttr(_userSocket,"close",out closeObj))
+                    PythonCalls.Call(closeObj);
                 Dispose(false); 
             }
 
@@ -2323,7 +2324,7 @@ namespace IronPython.Modules {
                
                 base.__init__(stream, System.Text.Encoding.Default, mode);
 
-                _isOpen = (socket == null) ? false : true;
+                _isOpen = socket != null;
                 _close = (socket == null) ? false : close;
             }
 


### PR DESCRIPTION
I notice when a _fileobject is created it check is a typeof socket if it is not that type it wraps it around PythonUserSocketStream and implicitly the _socket is set to null, I change that to be explicit. 

The change is on the close method if _socket is null check if the stream is not null and not closed, indicating that the PythonUserSocketStream is being use. If so call that close method. 

I then check in the PYthonUserSocketStream if the userSocket has a close method, if so call it. 

The other change _isOpen is set to false if a None object is passed in, this is the same behavior has CPython. I had to do it after the base.__init__ since it hard coded to always set _isOpen to true

I tested this against the test_socket_cpy and urllib2 and it passed.
