### PR TITLE
Modified PythonBinary:Read if size to read is zero return empty string

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/PythonFile.cs
+++ b/Languages/IronPython/IronPython/Runtime/PythonFile.cs
@@ -137,6 +137,11 @@ namespace IronPython.Runtime {
 
         // Read at most size characters (bytes in this case) and return the result as a string.
         public override String Read(int size) {
+
+            // If size is zero return empty string
+            if (size == 0)
+                return String.Empty;
+
             byte[] data;
             if (size <= BufferSize) {
                 if (_buffer == null)


### PR DESCRIPTION
If the size of the read is zero return a empty string. 
