### PR TITLE
collections.deque with maxLen=0 behaviour matches cpython

### DIFF
--- a/Languages/IronPython/IronPython.Modules/_collections.cs
+++ b/Languages/IronPython/IronPython.Modules/_collections.cs
@@ -154,6 +154,9 @@ namespace IronPython.Modules {
 
                     // overwrite head if queue is at max length
                     if (_itemCnt == _maxLen) {
+                        if (_maxLen == 0) {
+                            return;
+                        }
                         _data[_tail++] = x;
                         if (_tail == _data.Length) {
                             _tail = 0;

--- a/Languages/IronPython/Tests/test_stdmodules.py
+++ b/Languages/IronPython/Tests/test_stdmodules.py
@@ -87,8 +87,8 @@ def test_cp35507():
 
     import cPickle
     one = cPickle.dumps(1)
-    AreEqual(1, cPickle.loads("\nI1\n."))
-    AreEqual(1, cPickle.loads(b"\nI1\n."))
+    AreEqual(1, cPickle.loads("I1\n."))
+    AreEqual(1, cPickle.loads(b"I1\n."))
     AreEqual(1, cPickle.loads(one))
     AreEqual(1, cPickle.loads(bytes(one)))
 
@@ -268,6 +268,13 @@ def test_cp34188():
     import locale
     locale.setlocale(locale.LC_COLLATE,"de_CH")
     Assert(sorted([u'a', u'z', u'ä'], cmp=locale.strcoll) == sorted([u'a', u'z', u'ä'], key=locale.strxfrm))
+
+def test_gh1144():
+    from collections import deque
+    a = deque(maxlen=0)
+    a.append("a")
+    AreEqual(len(a), 0)
+
     
 ##MAIN#########################################################################
 run_test(__name__)


### PR DESCRIPTION
fixed #1144

It also includes test case adjustment - can not say why it was wrong in the first place. cPickle test case is consistent with cpython and passes.
