### PR TITLE
DOC Add Url cross-ref to the dev build instructions to both Ruby and Python Readme.txt.

### DIFF
--- a/Languages/IronPython/README.txt
+++ b/Languages/IronPython/README.txt
@@ -1,0 +1,29 @@
+Content description
+-------------------
+
+IronPython
+  - Core compiler and runtime (IronPython.dll)
+
+IronPython.Tests
+  - Targetted compiler and runtime unit tests hosted in a C# test harness.
+
+Public
+  - Misc documentation, tutorial
+
+Samples
+  - demonstrations, such as comment checker, voice.
+
+Scripts
+  - Infrastructure scripts and helpers.
+
+StdLib
+  - Python standard library imports. 
+
+Tests 
+  - Test suites.
+
+ 
+Please see http://wiki.github.com/IronLanguages/main for information on:
+- Setting up a development environment with easy access to utility scripts
+- Building
+- Running test

--- a/Languages/Ruby/README.txt
+++ b/Languages/Ruby/README.txt
@@ -51,5 +51,8 @@ StdLib
 Tests 
   - Test suites.
 
-  
-
+ 
+Please see http://wiki.github.com/IronLanguages/main for information on:
+- Setting up a development environment with easy access to utility scripts
+- Building
+- Running test


### PR DESCRIPTION
This modifies the ruby readme and  adds a python readme which has similar structure to the ruby.
Separate commits for each in case edits are desired.
This would have helped me since coming from google I got quite confused on where things were. 
AnneTHeAgile 
Note; Branch named pr-1158-doc-readme-annetheagile, anticipating this will be #158.