### PR TITLE
fix #1168 on 'l == r' try __rop_ before __op__ when r is subclass of l

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
+++ b/Languages/IronPython/IronPython/Runtime/Binding/PythonProtocol.Operations.cs
@@ -1149,11 +1149,24 @@ namespace IronPython.Runtime.Binding {
             bool shouldWarn = false;
             WarningInfo info = null;
 
+            // if the left operand is an instance of a built-in type or a new-style class, and the right operand is an instance of a proper subclass of that type or class
+            // and overrides the base’s __rop__() method, the right operand’s __rop__() method is tried before the left operand’s __op__() method.
+            PythonType xPythonType = MetaPythonObject.GetPythonType(xType);
+            bool opReverse = false;
+            if ((xPythonType.IsPythonType || !xPythonType.IsOldClass) &&
+                BindingHelpers.IsSubclassOf(yType, xType)) {
+                SlotOrFunction tmp = rop;
+                rop = fop;
+                fop = tmp;
+
+                opReverse = true;
+            }
+
             // first try __op__ or __rop__ and return the value
             shouldWarn = fop.ShouldWarn(state, out info);
-            if (MakeOneCompareGeneric(fop, false, types, MakeCompareReturn, bodyBuilder, typeof(object))) {
+            if (MakeOneCompareGeneric(fop, opReverse, types, MakeCompareReturn, bodyBuilder, typeof(object))) {
                 shouldWarn = shouldWarn || rop.ShouldWarn(state, out info);
-                if (MakeOneCompareGeneric(rop, true, types, MakeCompareReturn, bodyBuilder, typeof(object))) {
+                if (MakeOneCompareGeneric(rop, !opReverse, types, MakeCompareReturn, bodyBuilder, typeof(object))) {
 
                     // then try __cmp__ or __rcmp__ and compare the resulting int appropriaetly
                     shouldWarn = shouldWarn || cmp.ShouldWarn(state, out info);


### PR DESCRIPTION
Hi IronPython maintainers.

I've been using IronPython and now trying to hack on it. This is my first attempt :)

However there're some questions:
1. Which branch are you currently working on? I assume it's `ipy-2.7-maint`.
2. I noticed that tests related to this particular issue is disabled. What should I do to add some tests for this?
3. I've tried to run the tests on my machine and seems there's many failing cases. Is it always like this or am I doing something wrong?

Thanks.
