### PR TITLE
Update _weakref.cs

### DIFF
--- a/Languages/IronPython/IronPython.Modules/_weakref.cs
+++ b/Languages/IronPython/IronPython.Modules/_weakref.cs
@@ -172,14 +172,14 @@ namespace IronPython.Modules {
             [SpecialName]
             public object Call(CodeContext context) {
                 if (!_target.IsAlive) {
-                    throw PythonOps.ReferenceError("weak object has gone away");
+                    return null;
                 }
                 try {
                     object res = _target.Target;
                     GC.KeepAlive(this);
                     return res;
                 } catch (InvalidOperationException) {
-                    throw PythonOps.ReferenceError("weak object has gone away");
+                    return null;
                 }
             }
 


### PR DESCRIPTION
Return `null` (i.e. `None`) from `Call` (i.e. `__call__`) when the referenced
object doesn't exist anymore.

Fixes #1178.