### PR TITLE
InitializeModules can throw an ArgumentException

### DIFF
--- a/Languages/IronPython/IronPython/Hosting/PythonCommandLine.cs
+++ b/Languages/IronPython/IronPython/Hosting/PythonCommandLine.cs
@@ -228,7 +228,7 @@ namespace IronPython.Hosting {
 
         private void InitializeModules() {
             string executable = "";
-            string prefix = "";
+            string prefix = null;
 #if !SILVERLIGHT // paths     
             Assembly entryAssembly = Assembly.GetEntryAssembly();
             //Can be null if called from unmanaged code (VS integration scenario)


### PR DESCRIPTION
When Assembly.GetEntryAssembly() returns null, prefix remains an empty string and Path.GetDirectoryName(prefix) ends up throwing an ArgumentException.