### PR TITLE
Adjust _tokenEnd when buffer is refilled

### DIFF
--- a/Languages/IronPython/IronPython.SQLite/c#sqlite/select_c.cs
+++ b/Languages/IronPython/IronPython.SQLite/c#sqlite/select_c.cs
@@ -4969,7 +4969,7 @@ if (sqlite3AuthCheck(pParse, SQLITE_SELECT, 0, 0, 0)) return 1;
               Debug.Assert( !ExprHasProperty( p.pEList.a[0].pExpr, EP_xIsSelect ) );
               pMinMax = sqlite3ExprListDup( db, p.pEList.a[0].pExpr.x.pList, 0 );
               pDel = pMinMax;
-              if ( pMinMax != null )///* && 0 == db.mallocFailed */ )
+              if ( pMinMax != null )// /* && 0 == db.mallocFailed */ )
               {
                 pMinMax.a[0].sortOrder = (u8)( flag != WHERE_ORDERBY_MIN ? 1 : 0 );
                 pMinMax.a[0].pExpr.op = TK_COLUMN;

--- a/Languages/IronPython/IronPython.SQLite/c#sqlite/where_c.cs
+++ b/Languages/IronPython/IronPython.SQLite/c#sqlite/where_c.cs
@@ -5795,7 +5795,7 @@ whereBeginError:
         ** that reference the table and converts them into opcodes that
         ** reference the index.
         */
-        if ( ( pLevel.plan.wsFlags & WHERE_INDEXED ) != 0 )///* && 0 == db.mallocFailed */ )
+        if ( ( pLevel.plan.wsFlags & WHERE_INDEXED ) != 0 )// /* && 0 == db.mallocFailed */ )
         {
           int k, j, last;
           VdbeOp pOp;

--- a/Languages/IronPython/IronPython/Compiler/Tokenizer.cs
+++ b/Languages/IronPython/IronPython/Compiler/Tokenizer.cs
@@ -1877,6 +1877,9 @@ namespace IronPython.Compiler {
                 ResizeInternal(ref _buffer, new_size, _start, _end - _start);
                 _end -= _start;
                 _position -= _start;
+                _tokenEnd -= _start;
+                if (_tokenEnd < 0)
+                    _tokenEnd = -1;
                 _start = 0;
                 _bufferResized = true;
             }

--- a/Runtime/Microsoft.Scripting/IndexSpan.cs
+++ b/Runtime/Microsoft.Scripting/IndexSpan.cs
@@ -69,6 +69,10 @@ namespace Microsoft.Scripting {
             return _length == other._length && _start == other._start;
         }
 
+        public override string ToString()
+        {
+            return string.Format("Index Span: [{0} .. {1})", Start, End);
+        }
         #endregion
     }
 }


### PR DESCRIPTION
When buffer is refilled and shifted, all internal pointers to the buffer need to be adjusted, including the  _tokenEnd, which together with _start, points to the location of the token in the buffer.

Also add a space to ///\* to break error CS1570 when generating XML document from comments.
