### PR TITLE
Disable CS1570 warnings for commented out source code

### DIFF
--- a/Languages/IronPython/IronPython.SQLite/c#sqlite/select_c.cs
+++ b/Languages/IronPython/IronPython.SQLite/c#sqlite/select_c.cs
@@ -4969,7 +4969,9 @@ if (sqlite3AuthCheck(pParse, SQLITE_SELECT, 0, 0, 0)) return 1;
               Debug.Assert( !ExprHasProperty( p.pEList.a[0].pExpr, EP_xIsSelect ) );
               pMinMax = sqlite3ExprListDup( db, p.pEList.a[0].pExpr.x.pList, 0 );
               pDel = pMinMax;
+              #pragma warning disable 1570
               if ( pMinMax != null )///* && 0 == db.mallocFailed */ )
+              #pragma warning restore 1570
               {
                 pMinMax.a[0].sortOrder = (u8)( flag != WHERE_ORDERBY_MIN ? 1 : 0 );
                 pMinMax.a[0].pExpr.op = TK_COLUMN;

--- a/Languages/IronPython/IronPython.SQLite/c#sqlite/where_c.cs
+++ b/Languages/IronPython/IronPython.SQLite/c#sqlite/where_c.cs
@@ -5795,7 +5795,9 @@ whereBeginError:
         ** that reference the table and converts them into opcodes that
         ** reference the index.
         */
+        #pragma warning disable 1570
         if ( ( pLevel.plan.wsFlags & WHERE_INDEXED ) != 0 )///* && 0 == db.mallocFailed */ )
+        #pragma warning restore 1570
         {
           int k, j, last;
           VdbeOp pOp;


### PR DESCRIPTION
When performing an msbuild from command line, we see the following:
```
Build FAILED.

"C:\Projects\IronLanguages\main\Solutions\IronPython.sln" (default target) (1)
->
"C:\Projects\IronLanguages\main\Languages\IronPython\IronPython.SQLite\IronPyth
on.SQLite.csproj" (default target) (14) ->
(CoreCompile target) ->
  c#sqlite\select_c.cs(4972,42): error CS1570: XML comment has badly formed XML
 -- '&' [C:\Projects\IronLanguages\main\Languages\IronPython\IronPython.SQLite\
IronPython.SQLite.csproj]
  c#sqlite\select_c.cs(4972,43): error CS1570: XML comment has badly formed XML
 -- '{0}' [C:\Projects\IronLanguages\main\Languages\IronPython\IronPython.SQLit
e\IronPython.SQLite.csproj]
  c#sqlite\where_c.cs(5798,65): error CS1570: XML comment has badly formed XML
-- '&' [C:\Projects\IronLanguages\main\Languages\IronPython\IronPython.SQLite\I
ronPython.SQLite.csproj]
  c#sqlite\where_c.cs(5798,66): error CS1570: XML comment has badly formed XML
-- '{0}' [C:\Projects\IronLanguages\main\Languages\IronPython\IronPython.SQLite
\IronPython.SQLite.csproj]

    0 Warning(s)
    4 Error(s)
```

The lines in question are commented out source code, so disable the warning.