### PR TITLE
Add additional error message in IEnumeratorOFTWrapper

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/ConversionWrappers.cs
+++ b/Languages/IronPython/IronPython/Runtime/ConversionWrappers.cs
@@ -222,9 +222,23 @@ namespace IronPython.Runtime {
         }
 
         #region IEnumerator<T> Members
-
-        public T Current {
-            get { return (T)enumerable.Current; }
+        public T Current
+        {
+            get
+            {
+                try
+                {
+                    return (T)enumerable.Current;
+                }
+                catch (System.InvalidCastException iex)
+                {
+                    throw new System.Exception(string.Format("Error in IEnumeratorOfTWrapper.Current(). Could not cast: {0} in {0}", typeof(T).ToString(), enumerable.Current.GetType().ToString()), iex);
+                }
+                catch (System.Exception ex)
+                {
+                    throw ex;
+                }
+            }
         }
 
         #endregion

--- a/Languages/IronPython/IronPython/Runtime/ConversionWrappers.cs
+++ b/Languages/IronPython/IronPython/Runtime/ConversionWrappers.cs
@@ -232,7 +232,7 @@ namespace IronPython.Runtime {
                 }
                 catch (System.InvalidCastException iex)
                 {
-                    throw new System.InvalidCastException(string.Format("Error in IEnumeratorOfTWrapper.Current(). Could not cast: {0} in {0}", typeof(T).ToString(), enumerable.Current.GetType().ToString()), iex);
+                    throw new System.InvalidCastException(string.Format("Error in IEnumeratorOfTWrapper.Current. Could not cast: {0} in {0}", typeof(T).ToString(), enumerable.Current.GetType().ToString()), iex);
                 }
                 catch (System.Exception ex)
                 {

--- a/Languages/IronPython/IronPython/Runtime/ConversionWrappers.cs
+++ b/Languages/IronPython/IronPython/Runtime/ConversionWrappers.cs
@@ -232,7 +232,7 @@ namespace IronPython.Runtime {
                 }
                 catch (System.InvalidCastException iex)
                 {
-                    throw new System.Exception(string.Format("Error in IEnumeratorOfTWrapper.Current(). Could not cast: {0} in {0}", typeof(T).ToString(), enumerable.Current.GetType().ToString()), iex);
+                    throw new System.InvalidCastException(string.Format("Error in IEnumeratorOfTWrapper.Current(). Could not cast: {0} in {0}", typeof(T).ToString(), enumerable.Current.GetType().ToString()), iex);
                 }
                 catch (System.Exception ex)
                 {

--- a/Languages/IronPython/IronPython/Runtime/ConversionWrappers.cs
+++ b/Languages/IronPython/IronPython/Runtime/ConversionWrappers.cs
@@ -234,10 +234,6 @@ namespace IronPython.Runtime {
                 {
                     throw new System.InvalidCastException(string.Format("Error in IEnumeratorOfTWrapper.Current. Could not cast: {0} in {0}", typeof(T).ToString(), enumerable.Current.GetType().ToString()), iex);
                 }
-                catch (System.Exception ex)
-                {
-                    throw ex;
-                }
             }
         }
 


### PR DESCRIPTION
Added some additional error message in IEnumeratorOFTWrapper, to get more information when calling c# method from IronPython and passing an IEnumeratorOFTWrapper<T>.

```
        public T Current {
            get
            {
                try
                {
                    return (T)enumerable.Current;
                }
                catch (System.InvalidCastException iex)
                {
                    throw new System.Exception(string.Format("Error in IEnumeratorOfTWrapper.Current. Could not cast: {0} in {0}", typeof(T).ToString() ,enumerable.Current.GetType().ToString(), iex);
                }
                catch (System.Exception ex)
                {
                    throw ex;
                }
            }
        }
```