### PR TITLE
fix bytearray iterator bug

### DIFF
--- a/Languages/IronPython/IronPython/Runtime/ByteArray.cs
+++ b/Languages/IronPython/IronPython/Runtime/ByteArray.cs
@@ -1392,8 +1392,12 @@ namespace IronPython.Runtime {
 
         #region IEnumerable Members
 
-        System.Collections.IEnumerator/*!*/ System.Collections.IEnumerable.GetEnumerator() {
-            return _bytes.GetEnumerator();
+        System.Collections.IEnumerator/*!*/ System.Collections.IEnumerable.GetEnumerator()
+        {
+            foreach (var _byte in _bytes)
+            {
+                yield return (int)_byte;
+            }
         }
 
         #endregion


### PR DESCRIPTION
Fixed the bug, that if iterating over a `bytearray`, a System.Byte instead of an integer was returned. Issue: #1237 