### PR TITLE
Fix some a minor pasto from the SSL change and update network related tests

### DIFF
--- a/External.LCA_RESTRICTED/Languages/IronPython/27/Lib/test/test_urllib2net.py
+++ b/External.LCA_RESTRICTED/Languages/IronPython/27/Lib/test/test_urllib2net.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import unittest
 from test import test_support
 from test.test_urllib2 import sanepathname2url
@@ -80,13 +78,13 @@ class CloseSocketTest(unittest.TestCase):
         # underlying socket
 
         # delve deep into response to fetch socket._socketobject
-        response = _urlopen_with_retry("http://www.python.org/")
+        response = _urlopen_with_retry("http://www.example.com/")
         abused_fileobject = response.fp
-        self.assertTrue(abused_fileobject.__class__ is socket._fileobject)
+        self.assertIs(abused_fileobject.__class__, socket._fileobject)
         httpresponse = abused_fileobject._sock
-        self.assertTrue(httpresponse.__class__ is httplib.HTTPResponse)
+        self.assertIs(httpresponse.__class__, httplib.HTTPResponse)
         fileobject = httpresponse.fp
-        self.assertTrue(fileobject.__class__ is socket._fileobject)
+        self.assertIs(fileobject.__class__, socket._fileobject)
 
         self.assertTrue(not fileobject.closed)
         response.close()
@@ -104,11 +102,9 @@ class OtherNetworkTests(unittest.TestCase):
 
     def test_ftp(self):
         urls = [
-            'ftp://ftp.kernel.org/pub/linux/kernel/README',
-            'ftp://ftp.kernel.org/pub/linux/kernel/non-existent-file',
-            #'ftp://ftp.kernel.org/pub/leenox/kernel/test',
-            'ftp://gatekeeper.research.compaq.com/pub/DEC/SRC'
-                '/research-reports/00README-Legal-Rules-Regs',
+            'ftp://ftp.debian.org/debian/README',
+            ('ftp://ftp.debian.org/debian/non-existent-file',
+             None, urllib2.URLError),
             ]
         self._test_urls(urls, self._extra_handlers())
 
@@ -125,6 +121,8 @@ class OtherNetworkTests(unittest.TestCase):
             self._test_urls(urls, self._extra_handlers(), retry=True)
         finally:
             os.remove(TESTFN)
+
+        self.assertRaises(ValueError, urllib2.urlopen,'./relative_path/to/file')
 
     # XXX Following test depends on machine configurations that are internal
     # to CNRI.  Need to set up a public server with the right authentication
@@ -155,15 +153,15 @@ class OtherNetworkTests(unittest.TestCase):
 ##             self._test_urls(urls, self._extra_handlers()+[bauth, dauth])
 
     def test_urlwithfrag(self):
-        urlwith_frag = "http://docs.python.org/glossary.html#glossary"
+        urlwith_frag = "http://www.pythontest.net/index.html#frag"
         with test_support.transient_internet(urlwith_frag):
             req = urllib2.Request(urlwith_frag)
             res = urllib2.urlopen(req)
             self.assertEqual(res.geturl(),
-                    "http://docs.python.org/glossary.html#glossary")
+                    "http://www.pythontest.net/index.html#frag")
 
     def test_fileno(self):
-        req = urllib2.Request("http://www.python.org")
+        req = urllib2.Request("http://www.example.com")
         opener = urllib2.build_opener()
         res = opener.open(req)
         try:
@@ -185,6 +183,16 @@ class OtherNetworkTests(unittest.TestCase):
             request.add_header('User-Agent','Test-Agent')
             opener.open(request)
             self.assertEqual(request.get_header('User-agent'),'Test-Agent')
+
+    def test_sites_no_connection_close(self):
+        # Some sites do not send Connection: close header.
+        # Verify that those work properly. (#issue12576)
+
+        URL = 'http://www.imdb.com' # No Connection:close
+        with test_support.transient_internet(URL):
+            req = urllib2.urlopen(URL)
+            res = req.read()
+            self.assertTrue(res)
 
     def _test_urls(self, urls, handlers, retry=True):
         import time
@@ -239,15 +247,15 @@ class OtherNetworkTests(unittest.TestCase):
 
 class TimeoutTest(unittest.TestCase):
     def test_http_basic(self):
-        self.assertTrue(socket.getdefaulttimeout() is None)
-        url = "http://www.python.org"
+        self.assertIsNone(socket.getdefaulttimeout())
+        url = "http://www.example.com"
         with test_support.transient_internet(url, timeout=None):
             u = _urlopen_with_retry(url)
-            self.assertTrue(u.fp._sock.fp._sock.gettimeout() is None)
+            self.assertIsNone(u.fp._sock.fp._sock.gettimeout())
 
     def test_http_default_timeout(self):
-        self.assertTrue(socket.getdefaulttimeout() is None)
-        url = "http://www.python.org"
+        self.assertIsNone(socket.getdefaulttimeout())
+        url = "http://www.example.com"
         with test_support.transient_internet(url):
             socket.setdefaulttimeout(60)
             try:
@@ -257,32 +265,32 @@ class TimeoutTest(unittest.TestCase):
             self.assertEqual(u.fp._sock.fp._sock.gettimeout(), 60)
 
     def test_http_no_timeout(self):
-        self.assertTrue(socket.getdefaulttimeout() is None)
-        url = "http://www.python.org"
+        self.assertIsNone(socket.getdefaulttimeout())
+        url = "http://www.example.com"
         with test_support.transient_internet(url):
             socket.setdefaulttimeout(60)
             try:
                 u = _urlopen_with_retry(url, timeout=None)
             finally:
                 socket.setdefaulttimeout(None)
-            self.assertTrue(u.fp._sock.fp._sock.gettimeout() is None)
+            self.assertIsNone(u.fp._sock.fp._sock.gettimeout())
 
     def test_http_timeout(self):
-        url = "http://www.python.org"
+        url = "http://www.example.com"
         with test_support.transient_internet(url):
             u = _urlopen_with_retry(url, timeout=120)
             self.assertEqual(u.fp._sock.fp._sock.gettimeout(), 120)
 
-    FTP_HOST = "ftp://ftp.mirror.nl/pub/gnu/"
+    FTP_HOST = 'ftp://ftp.debian.org/debian/'
 
     def test_ftp_basic(self):
-        self.assertTrue(socket.getdefaulttimeout() is None)
+        self.assertIsNone(socket.getdefaulttimeout())
         with test_support.transient_internet(self.FTP_HOST, timeout=None):
             u = _urlopen_with_retry(self.FTP_HOST)
-            self.assertTrue(u.fp.fp._sock.gettimeout() is None)
+            self.assertIsNone(u.fp.fp._sock.gettimeout())
 
     def test_ftp_default_timeout(self):
-        self.assertTrue(socket.getdefaulttimeout() is None)
+        self.assertIsNone(socket.getdefaulttimeout())
         with test_support.transient_internet(self.FTP_HOST):
             socket.setdefaulttimeout(60)
             try:
@@ -292,14 +300,14 @@ class TimeoutTest(unittest.TestCase):
             self.assertEqual(u.fp.fp._sock.gettimeout(), 60)
 
     def test_ftp_no_timeout(self):
-        self.assertTrue(socket.getdefaulttimeout() is None)
+        self.assertIsNone(socket.getdefaulttimeout(),)
         with test_support.transient_internet(self.FTP_HOST):
             socket.setdefaulttimeout(60)
             try:
                 u = _urlopen_with_retry(self.FTP_HOST, timeout=None)
             finally:
                 socket.setdefaulttimeout(None)
-            self.assertTrue(u.fp.fp._sock.gettimeout() is None)
+            self.assertIsNone(u.fp.fp._sock.gettimeout())
 
     def test_ftp_timeout(self):
         with test_support.transient_internet(self.FTP_HOST):

--- a/Languages/IronPython/IronPython.Modules/_ssl.cs
+++ b/Languages/IronPython/IronPython.Modules/_ssl.cs
@@ -36,7 +36,7 @@ using IronPython.Runtime.Types;
 [assembly: PythonModule("_ssl", typeof(IronPython.Modules.PythonSsl))]
 namespace IronPython.Modules {
     public static class PythonSsl {
-        public const string __doc__ = "Implementation module for SSL socket operations.";
+        public const string __doc__ = "Implementation module for SSL socket operations.  See the socket module\nfor documentation.";
         public const int OPENSSL_VERSION_NUMBER = 9437184;
         public static PythonTuple OPENSSL_VERSION_INFO = PythonTuple.MakeTuple(0, 0, 0, 0, 0);
         public const string OPENSSL_VERSION = "OpenSSL 0.0.0 (.NET SSL)";
@@ -80,7 +80,7 @@ namespace IronPython.Modules {
             [DefaultParameterValue(null)] string keyfile, 
             [DefaultParameterValue(null)] string certfile,
             [DefaultParameterValue(PythonSsl.CERT_NONE)]int certs_mode,
-            [DefaultParameterValue(-1)]int protocol,
+            [DefaultParameterValue(PythonSsl.PROTOCOL_SSLv23 | PythonSsl.OP_NO_SSLv2 | PythonSsl.OP_NO_SSLv3)]int protocol,
             [DefaultParameterValue(null)]string cacertsfile,
             [DefaultParameterValue(null)]object ciphers) {
             return new PythonSocket.ssl(

--- a/Languages/IronPython/IronPython/Lib/iptest/test_env.py
+++ b/Languages/IronPython/IronPython/Lib/iptest/test_env.py
@@ -51,8 +51,15 @@ if is_cli:
     is_orcas = len(clr.GetClrType(System.Reflection.Emit.DynamicMethod).GetConstructors()) == 8
 
 is_net40 = False
+is_net45 = False
+is_net45Or46 = False
+is_net46 = False
 if is_cli:
-    is_net40 = System.Environment.Version.Major==4
+    version = System.Environment.Version
+    is_net40 = version.Major == 4
+    is_net45 = is_net40 and version.Minor == 0 and version.Build == 30319 and version.Revision < 42000
+    is_net45Or46 = is_net40 and version.Minor == 0 and version.Build == 30319
+    is_net46 = is_net40 and version.Minor == 0 and version.Build == 30319 and version.Revision == 42000 
 
 is_dlr_in_ndp = False
 if is_net40:

--- a/Languages/IronPython/Tests/modules/network_related/_ssl_test.py
+++ b/Languages/IronPython/Tests/modules/network_related/_ssl_test.py
@@ -27,7 +27,7 @@ import socket
 
 #--GLOBALS---------------------------------------------------------------------
 SSL_URL      = "www.microsoft.com"
-SSL_ISSUER   = "Microsoft Secure Server Authority"
+SSL_ISSUER   = "CN=Symantec Class 3 EV SSL CA - G3, OU=Symantec Trust Network, O=Symantec Corporation, C=US"
 SSL_SERVER   = "www.microsoft.com"
 SSL_PORT     = 443
 SSL_REQUEST  = "GET / HTTP/1.0\r\nHost: www.microsoft.com\r\n\r\n"
@@ -38,41 +38,75 @@ SSL_RESPONSE = "Microsoft Corporation"
 
 
 #--TEST CASES------------------------------------------------------------------
-@skip("cli", "silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
+@skip("silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
 def test_CERT_NONE():
     AreEqual(real_ssl.CERT_NONE,
              0)
 
-@skip("cli", "silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
+@skip("silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
 def test_CERT_OPTIONAL():
     AreEqual(real_ssl.CERT_OPTIONAL,
              1)
 
-@skip("cli", "silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
+@skip("silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
 def test_CERT_REQUIRED():
     AreEqual(real_ssl.CERT_REQUIRED,
              2)
 
-@skip("cli", "silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
+@skip("silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
 def test_PROTOCOL_SSLv2():
     AreEqual(real_ssl.PROTOCOL_SSLv2,
              0)
 
-@skip("cli", "silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
+@skip("silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
 def test_PROTOCOL_SSLv23():
     AreEqual(real_ssl.PROTOCOL_SSLv23,
              2)
 
-@skip("cli", "silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
+@skip("silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
 def test_PROTOCOL_SSLv3():
     AreEqual(real_ssl.PROTOCOL_SSLv3,
              1)
 
-@skip("cli", "silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
+@skip("silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
 def test_PROTOCOL_TLSv1():
     AreEqual(real_ssl.PROTOCOL_TLSv1,
              3)
 
+@skip("silverlight")
+def test_PROTOCOL_TLSv1_1():
+    AreEqual(real_ssl.PROTOCOL_TLSv1_1,
+             4)
+
+@skip("silverlight")
+def test_PROTOCOL_TLSv1_2():
+    AreEqual(real_ssl.PROTOCOL_TLSv1_2,
+             5)
+
+@skip("silverlight")
+def test_OP_NO_SSLv2():
+    AreEqual(real_ssl.OP_NO_SSLv2,
+             0x1000000)
+
+@skip("silverlight")
+def test_OP_NO_SSLv3():
+    AreEqual(real_ssl.OP_NO_SSLv3,
+             0x2000000)
+
+@skip("silverlight")
+def test_OP_NO_TLSv1():
+    AreEqual(real_ssl.OP_NO_TLSv1,
+             0x4000000)
+
+@skip("silverlight")
+def test_OP_NO_TLSv1_1():
+    AreEqual(real_ssl.OP_NO_TLSv1_1,
+             0x10000000)
+
+@skip("silverlight")
+def test_OP_NO_TLSv1_2():
+    AreEqual(real_ssl.OP_NO_TLSv1_2,
+             0x8000000)
 
 def test_RAND_add():
     #--Positive
@@ -86,7 +120,7 @@ def test_RAND_add():
     #--Negative
     for g1, g2 in [ (None, None),
                     ("", None),
-                    #(None, 3.14), #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=24276
+                    (None, 3.14), #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=24276
                     ]:
         AssertError(TypeError, real_ssl.RAND_add, g1, g2)
     
@@ -162,7 +196,7 @@ def test_SSL_ERROR_ZERO_RETURN():
     AreEqual(real_ssl.SSL_ERROR_ZERO_RETURN, 6)
 
 
-@skip("cli", "silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
+@skip("silverlight") #http://ironpython.codeplex.com/WorkItem/View.aspx?WorkItemId=21411
 def test___doc__():
     expected_doc = """Implementation module for SSL socket operations.  See the socket module
 for documentation."""

--- a/Languages/IronPython/Tests/modules/network_related/socket_test.py
+++ b/Languages/IronPython/Tests/modules/network_related/socket_test.py
@@ -325,8 +325,8 @@ def test_getnameinfo():
     host, service = socket.getnameinfo( ("127.0.0.1", 80), 8)
     AreEqual(service, '80')
         
-    if is_cli:
-        AssertError(NotImplementedError, socket.getnameinfo, ("127.0.0.1", 80), 0)
+    host, service = socket.getnameinfo( ("127.0.0.1", 80), 0)
+    AreEqual(service, "http")
     #IP gives a TypeError
     #AssertError(SystemError, socket.getnameinfo, ("127.0.0.1"), 8)
     #AssertError(SystemError, socket.getnameinfo, (321), 8)
@@ -372,15 +372,11 @@ def test_gethostbyname_ex():
     AssertError(socket.gaierror, socket.gethostbyname_ex, "should never work")
     
 
-@retry_on_failure
 def test_getservbyport():
-    if is_cli:
-        AssertError(NotImplementedError, socket.getservbyport, 80)
+    AreEqual(socket.getservbyport(80), "http")
 
-@retry_on_failure        
 def test_getservbyname():
-    if is_cli:
-        AssertError(NotImplementedError, socket.getservbyname, "http")
+    AreEqual(socket.getservbyname("http"), 80)
 
 @retry_on_failure        
 def test_inet_ntop():


### PR DESCRIPTION

* test_urllib2net.py: Update from Python 2.10, except for not yet existing CachingFTPHandler.

This is so that the URLs that get tested are actually HTTP. Python.org now redirects to HTTPS.

* _ssl.cs:
   * __doc__ : updated to meet expected contents.
   * sslwrap: Update default parameter value for protocol to match previous change.
* socket.cs:
   * settimeout: Add non __doc__ comment about the 0.5s timeout behavior is a .Net thing, and not an IronPython thing.
   * getnameinfo: Remove __doc__ implying IronPtyhon doesn't have support for doing port/service lookups.
   * _fileobject: Add _sock field to mirror CPython and allow more of CPython's socket based tests to pass.
   * ssl: Update default protocol value to the new default.
   * ssl: Fix pasto for detecting Tls11 support.
   * GetProtocolType: Remove -1 as case for protocol since the ~OP_NO_ALL in the switch expression wasn't allowing it to work properly anyway.

* test_env.py: Add environment related booleans for net45/net46.

* _ssl_test.py:
   * Update issuer for microsoft.com.
   * Remove no longer necessary skips for CLI IronPython
   * Update getnameinfo/getservbyport related tests to reflect CLI IronPython .supports service <-> port number lookups.