### PR TITLE
Ensure GIT treats Pickle files as binary files 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -29,6 +29,7 @@
 *.exe binary
 *.bmp binary
 *.zip binary
+*.pickle binary
 
 # Do not normalize on commit.
 *.pdf -text


### PR DESCRIPTION
since their embedded \n's MUST NOT be expanded into \r\n by git.

This allows modules.misc's datetime pickled by cpy test to pass.


