### PR TITLE
Importer state

### DIFF
--- a/Languages/IronPython/IronPython.Modules/zipimport.cs
+++ b/Languages/IronPython/IronPython.Modules/zipimport.cs
@@ -140,6 +140,7 @@ to Zip archives.";
                     }
                 } else {
                     State = ImporterModuleState.Ignore;
+                    return;
                 }
 
                 _prefix = input.Replace(path, string.Empty);

--- a/Languages/IronPython/IronPython.Modules/zipimport.cs
+++ b/Languages/IronPython/IronPython.Modules/zipimport.cs
@@ -12,6 +12,7 @@ using IronPython.Zlib;
 using Microsoft.Scripting;
 using Microsoft.Scripting.Utils;
 using Microsoft.Scripting.Runtime;
+using IronPython.Modules;
 
 [assembly: PythonModule("zipimport", typeof(IronPython.Runtime.ZipImportModule))]
 namespace IronPython.Runtime {
@@ -41,7 +42,8 @@ to Zip archives.";
         }
 
         [PythonType]
-        public class zipimporter {
+        public class zipimporter : Modules.IImporterModule
+        {
             private const int MAXPATHLEN = 256;
 
             private string _archive;
@@ -102,6 +104,7 @@ to Zip archives.";
                 }
 
                 path = pathObj as string;
+                State = ImporterModuleState.Ready;
 
                 if (path.Length == 0)
                     throw MakeError("archive path is empty");
@@ -136,7 +139,7 @@ to Zip archives.";
                         zip_directory_cache.Add(path, _files);
                     }
                 } else {
-                    throw MakeError("not a Zip file");
+                    State = ImporterModuleState.Ignore;
                 }
 
                 _prefix = input.Replace(path, string.Empty);
@@ -167,6 +170,15 @@ to Zip archives.";
                 get {
                     return _prefix;
                 }
+            }
+
+            /// <summary>
+            /// Represents the state of the current zipimporter
+            /// </summary>
+            public ImporterModuleState State
+            {
+                get;
+                set;
             }
 
             public string __repr__() {

--- a/Languages/IronPython/IronPython/IronPython.csproj
+++ b/Languages/IronPython/IronPython/IronPython.csproj
@@ -70,6 +70,8 @@
     <Compile Include="Compiler\PythonDynamicExpression.cs" />
     <Compile Include="Compiler\UncollectableCompilationMode.Generated.cs" />
     <Compile Include="Compiler\RunnableScriptCode.cs" />
+    <Compile Include="Modules\importer\IImporterModule.cs" />
+    <Compile Include="Modules\importer\ImporterModuleState.cs" />
     <Compile Include="Modules\unicodedata.cs" />
     <Compile Include="Modules\_ast.cs" />
     <Compile Include="Properties\BuildInfo.Generated.cs" />
@@ -556,7 +558,6 @@
   <Import Project="$(SolutionDir)Versioning.targets" />
   <Target Name="BeforeBuild" DependsOnTargets="GenerateBuildInfo;GenerateCurrentVersion" />
   <Target Name="AfterBuild" DependsOnTargets="GeneratePolicy">
-    <Copy DestinationFolder="$(OutputPath)\Lib"
-          SourceFiles="$(OutputPath)..\..\External.LCA_RESTRICTED\Languages\IronPython\27\Lib\os.py" />
+    <Copy DestinationFolder="$(OutputPath)\Lib" SourceFiles="$(OutputPath)..\..\External.LCA_RESTRICTED\Languages\IronPython\27\Lib\os.py" />
   </Target>
 </Project>

--- a/Languages/IronPython/IronPython/Modules/importer/IImporterModule.cs
+++ b/Languages/IronPython/IronPython/Modules/importer/IImporterModule.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace IronPython.Modules
+{
+    /// <summary>
+    /// Can be inherited for stateful importer modules, such as zipimporter
+    /// </summary>
+    public interface IImporterModule
+    {
+        /// <summary>
+        /// Current state of the importer
+        /// </summary>
+        ImporterModuleState State
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/Languages/IronPython/IronPython/Modules/importer/ImporterModuleState.cs
+++ b/Languages/IronPython/IronPython/Modules/importer/ImporterModuleState.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace IronPython.Modules
+{
+    /// <summary>
+    /// Represents a state whether modules can be imported with a given module or not
+    /// </summary>
+    public enum ImporterModuleState
+    {
+        /// <summary>
+        /// Is ready to be used for importing
+        /// </summary>
+        Ready = 0,
+
+        /// <summary>
+        /// Will be ignored when trying to import data
+        /// </summary>
+        Ignore = 1
+    }
+}

--- a/Languages/IronPython/IronPython/Runtime/Importer.cs
+++ b/Languages/IronPython/IronPython/Runtime/Importer.cs
@@ -921,7 +921,7 @@ namespace IronPython.Runtime {
                     {
                         if (handler is IImporterModule)
                         {
-                            if ((handler as IImporterModule).State == ImporterModuleState.Ready)
+                            if (((IImporterModule)handler).State == ImporterModuleState.Ready)
                             {
                                 return handler;
                             }

--- a/Languages/IronPython/IronPython/Runtime/Importer.cs
+++ b/Languages/IronPython/IronPython/Runtime/Importer.cs
@@ -916,7 +916,7 @@ namespace IronPython.Runtime {
             foreach (object hook in (IEnumerable)pathHooks) {
                 try {
                     object handler = PythonCalls.Call(context, hook, dirname);
-                    Debugger.Launch();
+
                     if (handler != null)
                     {
                         if (handler is IImporterModule)

--- a/Languages/IronPython/IronPython/Runtime/Importer.cs
+++ b/Languages/IronPython/IronPython/Runtime/Importer.cs
@@ -917,8 +917,19 @@ namespace IronPython.Runtime {
                 try {
                     object handler = PythonCalls.Call(context, hook, dirname);
 
-                    if (handler != null) {
-                        return handler;
+                    if (handler != null)
+                    {
+                        if (handler is IImporterModule)
+                        {
+                            if ((handler as IImporterModule).State == ImporterModuleState.Ready)
+                            {
+                                return handler;
+                            }
+                        }
+                        else
+                        {
+                            return handler;
+                        }
                     }
                 } catch (ImportException) {
                     // we can't handle the path

--- a/Languages/IronPython/IronPython/Runtime/Importer.cs
+++ b/Languages/IronPython/IronPython/Runtime/Importer.cs
@@ -916,7 +916,7 @@ namespace IronPython.Runtime {
             foreach (object hook in (IEnumerable)pathHooks) {
                 try {
                     object handler = PythonCalls.Call(context, hook, dirname);
-
+                    Debugger.Launch();
                     if (handler != null)
                     {
                         if (handler is IImporterModule)


### PR DESCRIPTION
Add a state option for import modules, to get rid of throwing exceptions if it the module not be used for importing some other modules or packages.

**EDIT**
Note, everything should be backward compatible, so it won't cause any problems.