### PR TITLE
Fix failures exposed via test_datetime.py

### DIFF
--- a/Languages/IronPython/IronPython.Modules/_collections.cs
+++ b/Languages/IronPython/IronPython.Modules/_collections.cs
@@ -435,7 +435,7 @@ namespace IronPython.Modules {
                     });
 
                     return PythonTuple.MakeTuple(
-                        DynamicHelpers.GetPythonTypeFromType(GetType()),
+                        DynamicHelpers.GetPythonType(this),
                         PythonTuple.MakeTuple(List.FromArrayNoCopy(items)),
                         null
                     );

--- a/Languages/IronPython/IronPython.Modules/datetime.cs
+++ b/Languages/IronPython/IronPython.Modules/datetime.cs
@@ -693,7 +693,7 @@ namespace IronPython.Modules {
                 if (string.IsNullOrEmpty(dateFormat)) {
                     return PythonOps.ToString(context, this);
                 } else {
-                    return this.strftime(context, dateFormat);
+                    return strftime(context, dateFormat);
                 }
             }
 
@@ -1502,7 +1502,7 @@ namespace IronPython.Modules {
                     // If we're a subtype, there might be a strftime overload,
                     // so call it if it exists.
                     if (GetType() == typeof(time)) {
-                        return this.strftime(context, dateFormat);
+                        return strftime(context, dateFormat);
                     }
                     else {
                         return PythonOps.Invoke(context, this, "strftime", dateFormat);

--- a/Languages/IronPython/IronPython/Runtime/Set.cs
+++ b/Languages/IronPython/IronPython/Runtime/Set.cs
@@ -159,7 +159,8 @@ namespace IronPython.Runtime {
         }
 
         public PythonTuple __reduce__() {
-            return SetStorage.Reduce(_items, TypeCache.Set);
+            var type = GetType() != typeof(SetCollection) ? DynamicHelpers.GetPythonType(this) : TypeCache.Set;
+            return SetStorage.Reduce(_items, type);
         }
 
         #endregion
@@ -1034,7 +1035,8 @@ namespace IronPython.Runtime {
         }
 
         public PythonTuple __reduce__() {
-            return SetStorage.Reduce(_items, TypeCache.FrozenSet);
+            var type = GetType() != typeof(FrozenSetCollection) ? DynamicHelpers.GetPythonType(this) : TypeCache.FrozenSet;
+            return SetStorage.Reduce(_items, type);
         }
 
         #endregion


### PR DESCRIPTION
* constructing a subclass of datetime/date failed due to the protected constructor
* pickling a subclass of datetime/date/time faile.
* time was missing its __format__ implementation.
  test_datetime tests overloading strftime, so __format__ calls it if necessary.
* Apply the same pickling fix to SetCollection/FrozenSetCollection and deque.

This PR has fixes for these problems.