### PR TITLE
Update uses of Close/Dispose

### DIFF
--- a/Languages/IronPython/IronPython.Modules/_winreg.cs
+++ b/Languages/IronPython/IronPython.Modules/_winreg.cs
@@ -494,7 +494,7 @@ namespace IronPython.Modules {
                 lock (this) {
                     if (key != null) {
                         HKeyHandleCache.cache.Remove(key.GetHashCode());
-                        key.Close();
+                        key.Dispose();
                         key = null;
                     }
                 }

--- a/Languages/IronPython/IronPython.Modules/bz2/dotnetzip/BZip2/BZip2InputStream.cs
+++ b/Languages/IronPython/IronPython.Modules/bz2/dotnetzip/BZip2/BZip2InputStream.cs
@@ -397,7 +397,6 @@ namespace Ionic.BZip2
             throw new NotImplementedException();
         }
 
-
         /// <summary>
         ///   Dispose the stream.
         /// </summary>
@@ -406,21 +405,29 @@ namespace Ionic.BZip2
         /// </param>
         protected override void Dispose(bool disposing)
         {
-            try
+            if (_disposed) return;
+
+            if (disposing)
             {
-                if (!_disposed)
+                Stream input = this.input;
+                if (input != null)
                 {
-                    if (disposing && (this.input != null))
-                        this.input.Close();
-                    _disposed = true;
+                    try
+                    {
+                        if (!this._leaveOpen)
+                            input.Dispose();
+                    }
+                    finally
+                    {
+                        this.data = null;
+                        this.input = null;
+                    }
                 }
             }
-            finally
-            {
-                base.Dispose(disposing);
-            }
-        }
 
+            _disposed = true;
+            base.Dispose(disposing);
+        }
 
         void init()
         {
@@ -547,28 +554,6 @@ namespace Ionic.BZip2
                 throw new IOException(msg);
             }
         }
-
-        /// <summary>
-        ///   Close the stream.
-        /// </summary>
-        public override void Close()
-        {
-            Stream inShadow = this.input;
-            if (inShadow != null)
-            {
-                try
-                {
-                    if (!this._leaveOpen)
-                        inShadow.Close();
-                }
-                finally
-                {
-                    this.data = null;
-                    this.input = null;
-                }
-            }
-        }
-
 
         /// <summary>
         ///   Read n bits from input, right justifying the result.

--- a/Languages/IronPython/IronPython.Modules/bz2/dotnetzip/BZip2/BZip2OutputStream.cs
+++ b/Languages/IronPython/IronPython.Modules/bz2/dotnetzip/BZip2/BZip2OutputStream.cs
@@ -204,29 +204,21 @@ namespace Ionic.BZip2
             EmitHeader();
         }
 
-
-
-
-        /// <summary>
-        ///   Close the stream.
-        /// </summary>
-        /// <remarks>
-        ///   <para>
-        ///     This may or may not close the underlying stream.  Check the
-        ///     constructors that accept a bool value.
-        ///   </para>
-        /// </remarks>
-        public override void Close()
+        protected override void Dispose(bool disposing)
         {
-            if (output != null)
+            if (disposing)
             {
-                Stream o = this.output;
-                Finish();
-                if (!leaveOpen)
-                    o.Close();
+                Stream output = this.output;
+                if (output != null)
+                {
+                    Finish(); // sets output to null
+                    if (!leaveOpen)
+                        output.Dispose();
+                }
             }
-        }
 
+            base.Dispose(disposing);
+        }
 
         /// <summary>
         ///   Flush the stream.

--- a/Languages/IronPython/IronPython.Modules/bz2/dotnetzip/BZip2/CRC32.cs
+++ b/Languages/IronPython/IronPython.Modules/bz2/dotnetzip/BZip2/CRC32.cs
@@ -788,22 +788,26 @@ namespace Ionic.Crc
             throw new NotSupportedException();
         }
 
-
-        void IDisposable.Dispose()
+        protected override void Dispose(bool disposing)
         {
-            Close();
-        }
+            if (disposing)
+            {
+                System.IO.Stream _innerStream = this._innerStream;
+                if (_innerStream != null)
+                {
+                    try
+                    {
+                        if (!_leaveOpen)
+                            _innerStream.Dispose();
+                    }
+                    finally
+                    {
+                        this._innerStream = null;
+                    }
+                }
+            }
 
-        /// <summary>
-        /// Closes the stream.
-        /// </summary>
-        public override void Close()
-        {
-            base.Close();
-            if (!_leaveOpen)
-                _innerStream.Close();
+            base.Dispose(disposing);
         }
-
     }
-
 }

--- a/Languages/IronPython/IronPython.Modules/bz2/dotnetzip/BZip2/ParallelBZip2OutputStream.cs
+++ b/Languages/IronPython/IronPython.Modules/bz2/dotnetzip/BZip2/ParallelBZip2OutputStream.cs
@@ -411,16 +411,7 @@ namespace Ionic.BZip2
             }
         }
 
-        /// <summary>
-        ///   Close the stream.
-        /// </summary>
-        /// <remarks>
-        ///   <para>
-        ///     This may or may not close the underlying stream.  Check the
-        ///     constructors that accept a bool value.
-        ///   </para>
-        /// </remarks>
-        public override void Close()
+        protected override void Dispose(bool disposing)
         {
             if (this.pendingException != null)
             {
@@ -433,25 +424,27 @@ namespace Ionic.BZip2
             if (this.handlingException)
                 return;
 
-            if (output == null)
-                return;
-
-            Stream o = this.output;
-
-            try
+            if (disposing)
             {
-                FlushOutput(true);
-            }
-            finally
-            {
-                this.output = null;
-                this.bw = null;
+                Stream output = this.output;
+                if (output != null)
+                {
+                    try
+                    {
+                        FlushOutput(true);
+                        if (!leaveOpen)
+                            output.Dispose();
+                    }
+                    finally
+                    {
+                        this.output = null;
+                        this.bw = null;
+                    }
+                }
             }
 
-            if (!leaveOpen)
-                o.Close();
+            base.Dispose(disposing);
         }
-
 
         private void FlushOutput(bool lastInput)
         {

--- a/Languages/IronPython/IronPython.Modules/socket.cs
+++ b/Languages/IronPython/IronPython.Modules/socket.cs
@@ -271,7 +271,7 @@ namespace IronPython.Modules {
                         }
                     }
 
-                    _socket.Close();
+                    ((IDisposable)_socket).Dispose();
                     _referenceCount = 0;
                 }
             }
@@ -2239,13 +2239,6 @@ namespace IronPython.Modules {
                 get { return true; }
             }
 
-            public override void Close() {
-                object closeObj;
-                if(PythonOps.TryGetBoundAttr(_userSocket,"close",out closeObj))
-                    PythonCalls.Call(closeObj);
-                Dispose(false); 
-            }
-
             public override void Flush() {
                 if (_data.Count > 0) {
                     StringBuilder res = new StringBuilder();
@@ -2295,6 +2288,12 @@ namespace IronPython.Modules {
             }
 
             protected override void Dispose(bool disposing) {
+                if (disposing) {
+                    object closeObj;
+                    if (PythonOps.TryGetBoundAttr(_userSocket, "close", out closeObj))
+                        PythonCalls.Call(closeObj);
+                }
+
                 base.Dispose(disposing);
             }
         }
@@ -2633,7 +2632,7 @@ namespace IronPython.Modules {
                         _sslStream.AuthenticateAsClient(_socket._hostName, collection, GetProtocolType(_protocol), false);
                     }
                 } catch (AuthenticationException e) {
-                    _socket._socket.Close();
+                    ((IDisposable)_socket._socket).Dispose();
                     throw PythonExceptions.CreateThrowable(PythonSsl.SSLError(_context), "errors while performing handshake: ", e.ToString());
                 }
 

--- a/Languages/IronPython/IronPython.Modules/thread.cs
+++ b/Languages/IronPython/IronPython.Modules/thread.cs
@@ -193,7 +193,7 @@ namespace IronPython.Modules {
             private void CreateBlockEvent() {
                 AutoResetEvent are = new AutoResetEvent(false);
                 if (Interlocked.CompareExchange<AutoResetEvent>(ref blockEvent, are, null) != null) {
-                    are.Close();
+                    ((IDisposable)are).Dispose();
                 }
             }
         }

--- a/Languages/IronPython/IronPython.Modules/zipimport.cs
+++ b/Languages/IronPython/IronPython.Modules/zipimport.cs
@@ -421,7 +421,7 @@ contain the module, but has no source for it.")]
 
                 } finally {
                     if (fp != null) {
-                        fp.Close();
+                        ((IDisposable)fp).Dispose();
                     }
                 }
 
@@ -505,7 +505,7 @@ contain the module, but has no source for it.")]
 
                     if (BitConverter.ToUInt32(endof_central_dir, 0) != 0x06054B50) {
                         // Bad: End of Central Dir signature
-                        fp.Close();
+                        ((IDisposable)fp).Dispose();
                         throw MakeError(context, "not a Zip file: '{0}'", archive);
                     }
 
@@ -557,7 +557,7 @@ contain the module, but has no source for it.")]
                     }
                 } finally {
                     if (fp != null) {
-                        fp.Close();
+                        ((IDisposable)fp).Dispose();
                     }
                 }
 

--- a/Languages/IronPython/IronPython/Runtime/PythonFile.cs
+++ b/Languages/IronPython/IronPython/Runtime/PythonFile.cs
@@ -985,7 +985,7 @@ namespace IronPython.Runtime {
         public void CloseIfLast(int fd, Stream stream) {
             objMapping.RemoveOnId(fd);
             if (-1 == objMapping.GetIdFromObject(stream)) {
-                stream.Close();
+                ((IDisposable)stream).Dispose();
             }
         }
 
@@ -1516,7 +1516,7 @@ namespace IronPython.Runtime {
                 _isOpen = false;
 
                 if (!IsConsole) {
-                    _stream.Close();
+                    ((IDisposable)_stream).Dispose();
                 }
 
                 PythonFileManager myManager = _context.RawFileManager;

--- a/Runtime/Microsoft.Dynamic/Hosting/Shell/BasicConsole.cs
+++ b/Runtime/Microsoft.Dynamic/Hosting/Shell/BasicConsole.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Scripting.Hosting.Shell {
 
         public void Dispose() {
             if (_ctrlCEvent != null) {
-                _ctrlCEvent.Close();
+                ((IDisposable)_ctrlCEvent).Dispose();
             }
 
             GC.SuppressFinalize(this);


### PR DESCRIPTION
This updates uses of Close/Dispose to work with .NET Core. These changes are requires since `Close` was removed from various classes (e.g. `Stream`).