### PR TITLE
Make test runner use the correct configuration

### DIFF
--- a/Test/test-ipy-tc.cmd
+++ b/Test/test-ipy-tc.cmd
@@ -2,8 +2,24 @@
 
 setlocal
 
+if "%DLR_BIN%"=="" (
+  echo "You must set DLR_BIN before running this command"
+  exit /b -1
+)
+
+if "%DLR_ROOT%"=="" (
+  echo "You must set DLR_ROOT before running this command"
+  exit /b -1
+)
+
 set _test_root=%DLR_ROOT%\Test
-set _runner=%_test_root%\TestRunner\TestRunner\bin\Debug\TestRunner.exe
+set _config=%CONFIGURATION%
+if "%_config%"=="" (
+  set _config=Debug
+)
+
+set _runner=%_test_root%\TestRunner\TestRunner\bin\%_config%\TestRunner.exe
+
 
 call :build_runner
 
@@ -13,6 +29,6 @@ endlocal
 goto:eof
 
 :build_runner
-%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe /t:Rebuild %_test_root%\ClrAssembly\ClrAssembly.csproj /p:Configuration=Debug /v:quiet /nologo
-%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe /t:Rebuild %_test_root%\TestRunner\TestRunner.sln /p:Configuration=Debug /v:quiet /nologo
+%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe /t:Rebuild %_test_root%\ClrAssembly\ClrAssembly.csproj /p:Configuration=%_config% /v:quiet /nologo
+%windir%\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe /t:Rebuild %_test_root%\TestRunner\TestRunner.sln /p:Configuration=%_config% /v:quiet /nologo
 goto:eof


### PR DESCRIPTION
This makes it so that the TestRunner uses the correct configuration (CONFIGURATION environment variable). Also added error messages if key environment variables are not set.
