### PR TITLE
appveyor.yml: query CurrentVersion.props for version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,8 @@
 #---------------------------------#
 
 # version format
-version: 2.7.6-{build}
+# NOTE: version is now generated in "before_build:"
+#version: 2.7.6-{build}
 
 # you can use {branch} name in version format too
 # version: 1.0.{build}-{branch}
@@ -56,6 +57,7 @@ configuration: Release
 # scripts to run before build
 before_build:
   - set DLR_ROOT=%APPVEYOR_BUILD_FOLDER%
+  - ps: $xml = [xml] (Get-Content CurrentVersion.props); $major = $xml.Project.PropertyGroup.MajorVersion; $minor = $xml.Project.PropertyGroup.MinorVersion; $micro = $xml.Project.PropertyGroup.MicroVersion; $serial = $xml.Project.PropertyGroup.ReleaseSerial; Update-AppveyorBuild -Version "$($major).$($minor).$($micro).$($serial)-$($env:APPVEYOR_BUILD_NUMBER)".replace(" ","")
 
 # scripts to run *after* solution is built and *before* automatic packaging occurs (web apps, NuGet packages, Azure Cloud Services)
 before_package:


### PR DESCRIPTION
- Rather than hard code the build version, query from source.
- This cannot be in "init:" phase because git repo is not cloned yet.
- Strip any spaces in the resulting version construct

Signed-off-by: Tim Orling timothy.t.orling@linux.intel.com
